### PR TITLE
Print Debug-RC Logs in formatted way

### DIFF
--- a/pytest_cafy/plugin.py
+++ b/pytest_cafy/plugin.py
@@ -1274,8 +1274,8 @@ class EmailReport(object):
                                               "exception_name": rc_exception_name_list}
                                     response = self.invoke_rc_on_failed_testcase(params, headers)
                                     if response is not None and response.status_code == 200:
-                                        if response.text:
-                                            self.log.info("Debug RC logs: %s" % response.text)
+                                        if response.json().get("traffic_logs"):
+                                            self.log.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
                     else:
                         self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
 


### PR DESCRIPTION
Print Debug-RC Logs in formatted way

http://allure.cisco.com//auto/tftp-aj-sjc/cafy/mine/cafykit/work/archive/sr_ap_20200612-181733_p18547/all.log
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/53624128/84690635-a5339e00-aef7-11ea-9fe0-b60e7547a19f.png">
