### PR TITLE
RC logs push to elastic, timeout increased for RC Call

### DIFF
--- a/pytest_cafy/plugin.py
+++ b/pytest_cafy/plugin.py
@@ -642,6 +642,7 @@ class EmailReport(object):
         self.topo_file = topo_file
         self.reg_dict = reg_dict
         self.log = CafyLog("cafy")
+        self.rclog = CafyLog("debug-rc")
         self.errored_testcase_count = {}
         self.analyzer_testcase = {}
         # using the first item of the script list for archive name as in most
@@ -1275,7 +1276,7 @@ class EmailReport(object):
                                     response = self.invoke_rc_on_failed_testcase(params, headers)
                                     if response is not None and response.status_code == 200:
                                         if response.json().get("traffic_logs"):
-                                            self.log.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
+                                            self.rclog.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
                     else:
                         self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
 
@@ -1384,7 +1385,7 @@ class EmailReport(object):
             try:
                 url = "http://{0}:5001/startrootcause/".format(CafyLog.debug_server)
                 self.log.info("Calling RC engine to start rootcause (url:%s)" % url)
-                response = requests.post(url, json=params, headers=headers, timeout=300)
+                response = requests.post(url, json=params, headers=headers, timeout=600)
                 if response.status_code == 200:
                     return response
                 else:


### PR DESCRIPTION
1) RC Logs pushed to elastic with "debug-rc" name for API to fetch cafylogs only for RC
2) Timeout increased for RC engine call as cef collection & AP specific commands together take more than 5 mins now.

Related PRs:
https://wwwin-github.cisco.com/cafy/cafykit/pull/16287
https://wwwin-github.cisco.com/cafy/log-engine/pull/118

http://allure.cisco.com//auto/tftp-aj-sjc/cafy/mine/cafykit/work/archive/sr_ap_20200622-162523_p16614/all.log