### PR TITLE
changes for getting allure stack error into retest data json and cafylog

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -503,8 +503,8 @@ def pytest_configure(config):
                         reg_dict = {}
                         log.info("Registration server returned code %d " % response.status_code)
                 except Exception as e:
-                        log.error("Http call to registration service url:%s is not successful" % url)
-                        log.error("Error {}".format(e))
+                        log.warning("Http call to registration service url:%s is not successful" % url)
+                        log.warning("Error {}".format(e))
         else:
             reg_dict = {}
 
@@ -1086,10 +1086,10 @@ class EmailReport(object):
                         if response.status_code == 200:
                             self.log.info("Handshake to registration service successful")
                         else:
-                            self.log.error("Handshake part of registration server returned code %d " % response.status_code)
+                            self.log.warning("Handshake part of registration server returned code %d " % response.status_code)
                     except Exception as e:
-                        self.log.error("Error {}".format(e))
-                        self.log.error("Http call to registration service url:%s is not successful" % url)
+                        self.log.warning("Error {}".format(e))
+                        self.log.warning("Http call to registration service url:%s is not successful" % url)
 
 
 

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -784,6 +784,7 @@ class EmailReport(object):
         self.testcase_time = defaultdict(
             lambda : {'start_time': None, 'end_time': None})
         self.testcase_failtrace_dict = OrderedDict()
+        self.temp_json={}
 
     def _sendemail(self):
         print("\nSending Summary Email to %s" % self.email_addr_list)
@@ -1105,14 +1106,14 @@ class EmailReport(object):
             if testcase_name in self.testcase_dict:
                 status = self.testcase_dict[testcase_name].status
             try:
-                temp_json ={}
-                temp_json["name"] = testcase_name
-                temp_json["action"]= self.log.device_actions
-                temp_json['testcase_status'] = status
+                self.temp_json["name"] = testcase_name
+                self.temp_json["action"]= self.log.device_actions
+                self.temp_json['testcase_status'] = status
                 if status != "passed" :
-                    temp_json['error'] = CafyLog.fail_log_msg
-                    temp_json["exception"] = self.log.exception_details
-                self.log.buffer_to_retest.append(temp_json)
+                    self.temp_json['error'] = CafyLog.fail_log_msg
+                    self.temp_json["exception"] = self.log.exception_details
+                self.log.buffer_to_retest.append(self.temp_json)
+                self.temp_json={}
             except Exception as err:
                 self.log.info("Error {} happened while getting deta for retest" .format(err))
 
@@ -1220,8 +1221,12 @@ class EmailReport(object):
                 if testcase_status == 'failed':
                     if report.longrepr:
                         self.testcase_failtrace_dict[testcase_name] = report.longrepr
+                        self.temp_json["stack_exception"]=str(report.longrepr)
+                        self.log.error("stack_exception %s" %report.longrepr)
                     else:
                         self.testcase_failtrace_dict[testcase_name] = None
+                else:
+                    self.temp_json["stack_exception"]= ""
 
 
     def check_call_report(self, item, nextitem):


### PR DESCRIPTION
getting allure exception  stacks into cafylogs and in retest_data.json
**Proposed solution**
capturing the stack error of failed testcases during **"report.when == 'call'** and adding the stack error from **"report.longrepr"** during the testcase status ="failed" and finally appending the collected data into retest_data.json
                                               =========================
                                                                  Logs
                                                =========================

#TestLog1
retest_data.json for normal UT:
[test1_retest_data.json.zip](https://github.com/cafykit/cafy-pytest/files/8440702/test1_retest_data.json.zip)


#TestLog2
retest_data.json for AP testing (telemetry_aaa_oper)
[test2_retest_data.json.zip](https://github.com/cafykit/cafy-pytest/files/8440712/test2_retest_data.json.zip)

#TestLog3
retest_data.json for AP testing(aaa_tacacs_ap)
[test3_retest_data.json.zip](https://github.com/cafykit/cafy-pytest/files/8440716/test3_retest_data.json.zip)

 
