### PR TITLE
Remove the default value for -M arg

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -179,7 +179,7 @@ def pytest_addoption(parser):
                     help='Variable to enable live logging the status of testcases, default is False')
 
     group.addoption('-M', '--feature-lib-mode', type=str,
-                    choices=("cli", "ydk", "oc", "hybrid_ydk", "hybrid_oc"), default='ydk', dest='feature_lib_mode',
+                    choices=("cli", "ydk", "oc", "hybrid_ydk", "hybrid_oc"), dest='feature_lib_mode',
                     metavar='feature_lib_mode', help='Feature library mode')
 
     group.addoption('-D', "--unset-feature-lib-mode", action='store_true', dest='unset_feature_lib_mode',


### PR DESCRIPTION
Initially, the default value -f -M was being set to 'ydk'. This made -M a mandatory argument.
However, there are runs that may not need this -M arg whose default value is 'ydk'.
So removing the default value for -M will make it optional argument
pytest -s test/utils/test_selective_testcases.py -W ignore::DeprecationWarning
```
(Pdb) import os
(Pdb) os.env
*** AttributeError: module 'os' has no attribute 'env'
(Pdb) os.environ
environ({'VNCDESKTOP': 'x11', 'MANPATH': '/opt/quest/man::/opt/puppetlabs/puppet/share/man', 'SSH_AGENT_PID': '61363', 'XDG_SESSION_ID': '12382', 'DISPLAYNUM': '1', 'KDE_MULTIHEAD': 'false', 'HOSTNAME': 'sjc-ads-1448', 'SHELL': '/bin/bash', 'TERM': 'xterm', 'XDG_MENU_PREFIX': 'kde4-', 'GIT_REPO': '/ws/shreyash-sjc/cafyinfra/cafykit', 'HISTSIZE': '1000', 'SSH_CLIENT': '10.21.91.124 49199 22', 'KONSOLE_DBUS_SERVICE': ':1.46', 'PERL5LIB': '/users/shreyash/perl5/lib/perl5', 'KONSOLE_PROFILE_NAME': '', 'GS_LIB': '', 'WINDOWID': '52428826', 'OLDPWD': '/ws/shreyash-sjc/plugins/cafy-pytest', 'QTDIR': '/usr/lib64/qt-3.3', 'SHELL_SESSION_ID': 'f53742bf4d324000ae861095967eda2d', 'QTINC': '/usr/lib64/qt-3.3/include', 'PERL_MB_OPT': '--install_base "/users/shreyash/perl5"', 'SSH_TTY': '/dev/pts/0', 'KDE_FULL_SESSION': 'true', 'QT_GRAPHICSSYSTEM_CHECKED': '1', 'USER': 'shreyash', 'LS_COLORS': 'rs=0:di=38;5;27:ln=38;5;51:mh=44;38;5;15:pi=40;38;5;11:so=38;5;13:do=38;5;5:bd=48;5;232;38;5;11:cd=48;5;232;38;5;3:or=48;5;232;38;5;9:mi=05;48;5;232;38;5;15:su=48;5;196;38;5;15:sg=48;5;11;38;5;16:ca=48;5;196;38;5;226:tw=48;5;10;38;5;16:ow=48;5;10;38;5;21:st=48;5;21;38;5;15:ex=38;5;34:*.tar=38;5;9:*.tgz=38;5;9:*.arc=38;5;9:*.arj=38;5;9:*.taz=38;5;9:*.lha=38;5;9:*.lz4=38;5;9:*.lzh=38;5;9:*.lzma=38;5;9:*.tlz=38;5;9:*.txz=38;5;9:*.tzo=38;5;9:*.t7z=38;5;9:*.zip=38;5;9:*.z=38;5;9:*.Z=38;5;9:*.dz=38;5;9:*.gz=38;5;9:*.lrz=38;5;9:*.lz=38;5;9:*.lzo=38;5;9:*.xz=38;5;9:*.bz2=38;5;9:*.bz=38;5;9:*.tbz=38;5;9:*.tbz2=38;5;9:*.tz=38;5;9:*.deb=38;5;9:*.rpm=38;5;9:*.jar=38;5;9:*.war=38;5;9:*.ear=38;5;9:*.sar=38;5;9:*.rar=38;5;9:*.alz=38;5;9:*.ace=38;5;9:*.zoo=38;5;9:*.cpio=38;5;9:*.7z=38;5;9:*.rz=38;5;9:*.cab=38;5;9:*.jpg=38;5;13:*.jpeg=38;5;13:*.gif=38;5;13:*.bmp=38;5;13:*.pbm=38;5;13:*.pgm=38;5;13:*.ppm=38;5;13:*.tga=38;5;13:*.xbm=38;5;13:*.xpm=38;5;13:*.tif=38;5;13:*.tiff=38;5;13:*.png=38;5;13:*.svg=38;5;13:*.svgz=38;5;13:*.mng=38;5;13:*.pcx=38;5;13:*.mov=38;5;13:*.mpg=38;5;13:*.mpeg=38;5;13:*.m2v=38;5;13:*.mkv=38;5;13:*.webm=38;5;13:*.ogm=38;5;13:*.mp4=38;5;13:*.m4v=38;5;13:*.mp4v=38;5;13:*.vob=38;5;13:*.qt=38;5;13:*.nuv=38;5;13:*.wmv=38;5;13:*.asf=38;5;13:*.rm=38;5;13:*.rmvb=38;5;13:*.flc=38;5;13:*.avi=38;5;13:*.fli=38;5;13:*.flv=38;5;13:*.gl=38;5;13:*.dl=38;5;13:*.xcf=38;5;13:*.xwd=38;5;13:*.yuv=38;5;13:*.cgm=38;5;13:*.emf=38;5;13:*.axv=38;5;13:*.anx=38;5;13:*.ogv=38;5;13:*.ogx=38;5;13:*.aac=38;5;45:*.au=38;5;45:*.flac=38;5;45:*.mid=38;5;45:*.midi=38;5;45:*.mka=38;5;45:*.mp3=38;5;45:*.mpc=38;5;45:*.ogg=38;5;45:*.ra=38;5;45:*.wav=38;5;45:*.axa=38;5;45:*.oga=38;5;45:*.spx=38;5;45:*.xspf=38;5;45:', 'SSH_AUTH_SOCK': '/tmp/ssh-Zzjl14CiR8qq/agent.61325', 'SESSION_MANAGER': 'local/unix:@/tmp/.ICE-unix/61435,unix/unix:/tmp/.ICE-unix/61435', 'VIRTUAL_ENV': '/ws/shreyash-sjc/private_env', 'MAIL': '/var/spool/mail/shreyash', 'PATH': '/ws/shreyash-sjc/private_env/bin:/ws/shreyash-sjc/temp/bin:/usr/atria/bin:/usr/cisco/bin:/usr/cisco/etc:/bin:/usr/X11R6/bin:/usr/sbin:/sbin:/usr/bin:', 'PWD': '/ws/shreyash-sjc/cafyinfra/cafykit', 'KONSOLE_DBUS_WINDOW': '/Windows/1', 'KDE_SESSION_UID': '457700', 'LANG': 'en_US.UTF-8', 'KDEDIRS': '/usr', 'PS1': '(private_env) $(whoami)@$(hostname):\\W$ ', 'KONSOLE_DBUS_SESSION': '/Sessions/1', 'HISTCONTROL': 'ignoredups', 'HOME': '/users/shreyash', 'COLORFGBG': '15;0', 'SHLVL': '4', 'KDE_SESSION_VERSION': '4', 'LANGUAGE': '', 'XCURSOR_THEME': 'Adwaita', 'PERL_LOCAL_LIB_ROOT': '/users/shreyash/perl5', 'PYTHONPATH': '/ws/shreyash-sjc/cafyinfra/cafykit/lib', 'LOGNAME': 'shreyash', 'CVS_RSH': 'ssh', 'QTLIB': '/usr/lib64/qt-3.3/lib', 'XDG_DATA_DIRS': '/users/shreyash/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share', 'SSH_CONNECTION': '10.21.91.124 49199 171.70.59.140 22', 'DBUS_SESSION_BUS_ADDRESS': 'unix:abstract=/tmp/dbus-lGmx6yC4J0,guid=e36bd39cf517e95613d87bfe62587dfd', 'LESSOPEN': '||/usr/bin/lesspipe.sh %s', 'HISTMON_OS': 'Linux', 'PROFILEHOME': '/users/shreyash', 'XDG_RUNTIME_DIR': '/run/user/457700', 'DISPLAY': ':1', 'QT_PLUGIN_PATH': '/usr/lib64/kde4/plugins:/usr/lib/kde4/plugins:/users/shreyash/.kde/lib64/kde4/plugins/:/usr/lib64/kde4/plugins/', 'XDG_CURRENT_DESKTOP': 'KDE', 'PERL_MM_OPT': 'INSTALL_BASE=/users/shreyash/perl5', 'XAUTHORITY': '/tmp/kde-shreyash/xauth-457700-_1', '_': '/ws/shreyash-sjc/private_env/bin/pytest', 'CAFY_REPO': '/ws/shreyash-sjc/cafyinfra/cafykit', 'ARCHIVE_DIR': '/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_selective_testcases_20220427-094040_p56307', 'PYTEST_CURRENT_TEST': 'utils/test_selective_testcases.py::Test_A::test_two (call)'})
(Pdb) os.environ.get('feature_lib_mode')
(Pdb) os.environ.get('hybrid_mode')
(Pdb) q
Exit: Quitting debugger
```