### PR TITLE
added check for avoding call of startdebug api when there is fail in …

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1518,7 +1518,7 @@ class EmailReport(object):
 
                                 headers = {'content-type': 'application/json'}
 
-                                if len(collector_actual_obj_dict_list) > 0:
+                                if len(collector_actual_obj_dict_list) > 0 and report.when!='setup':
                                     params = {"testcase_name": testcase_name, "class_name": base_class_name,
                                               "inherited_classes": inherited_classes,
                                               "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,


### PR DESCRIPTION
**Description**

If testcase execution fail in setup module , due to name error, composite error , type error etc then "http://{0}:5001/startdebug/" api service getting called for the first testcase of each Test class which should not happen.

**Reproduced Error**

I have manually added an  error such as Name error by simply printing a var which is undeclared in setup module for an ap-> lldp_ap.py [added line (print(l) where l is undeclared at https://wwwin-github.cisco.com/cafy/cafyap/blob/master/pi_infra/lldp/lldp_ap.py#L64 in setup module of lldp_ap.py] in order to reproduced the error.

**Log of Reproduced error**

cmd used: pytest lldp_ap.py -I lldp_ap_input.json -T /auto/cafy/infra/cafykit/testbed/POD/PSI/ASR9K/F3A-ASR9900-MOD-POD18.json --debug-enable


[all.log](https://github.com/cafykit/cafy-pytest/files/9421451/all.log)



**Proposed Changes**

added check before calling api "http://{0}:5001/startdebug/" which was missing in some corner cases such as below:

**#case1**
at line https://github.com/cafykit/cafy-pytest/blob/master/cafy_pytest/plugin.py#L1436
if report.when!=setup false (if report.when = setup) and other first two condition in above line true then we enter inside if block and calling api "http://{0}:5001/startdebug/" even in setup fail case.

To avoid the call , I have added additional check before call as in PR

**Test Result Log**   

[all.log](https://github.com/cafykit/cafy-pytest/files/9421460/all.log)


Test Log case : No setup module error with PR Changes
http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20220829-100046_p24949/all.log 


