### PR TITLE
added missing case for the collection of stack exception for retest data

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1331,7 +1331,17 @@ class EmailReport(object):
         #The following if block is executed for @pytest.mark.xfail(run=False) and
         #@@pytest.mark.skip(..) markers because testcases marked with these
         #will never go into call stage
-        if report.when == 'setup' and report.outcome == 'skipped':
+        if report.when == 'setup':
+           testcase_name = self.get_test_name(report.nodeid)
+           testcase_status = report.outcome
+           self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
+           if testcase_status == 'failed':
+                if report.longrepr:
+                    self.temp_json["stack_exception"] = str(report.longrepr)
+                else:
+                    self.temp_json["stack_exception"] = ""
+
+        elif report.when == 'setup' and report.outcome == 'skipped':
             if hasattr(report, "wasxfail"):
                 #This is to handle tests that are marked with @pytest.mark.xfail(run=False)
                 #which means don't execute the testcase. Such testcase will never go into the
@@ -1345,12 +1355,11 @@ class EmailReport(object):
                 #report.when=call stage
                 testcase_name = self.get_test_name(report.nodeid)
                 self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,'skipped',report.longrepr)
-            '''
             if report.longrepr:
-                self.testcase_failtrace_dict[testcase_name] = report.longrepr
+                self.temp_json["stack_exception"]=str(report.longrepr)
             else:
-                self.testcase_failtrace_dict[testcase_name] = None
-            '''
+                self.temp_json["stack_exception"]=""
+
         elif report.when == 'call':
             testcase_name = self.get_test_name(report.nodeid)
             if hasattr(report, "wasxfail"):
@@ -1364,14 +1373,10 @@ class EmailReport(object):
                 self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
                 if testcase_status == 'failed':
                     self.testcase_failtrace_dict[testcase_name] = CafyLog.fail_log_msg
-                    #print('failmsg = ', self.testcase_failtrace_dict[testcase_name])
-                    #
-                '''
-                if report.longrepr:
-                    self.testcase_failtrace_dict[testcase_name] = report.longrepr
-                else:
-                    self.testcase_failtrace_dict[testcase_name] = None
-                '''
+                    if report.longrepr:
+                        self.temp_json["stack_exception"] = str(report.longrepr)
+                    else:
+                        self.temp_json["stack_exception"] = ""
             else:
                 testcase_status = report.outcome
                 self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
@@ -1384,7 +1389,6 @@ class EmailReport(object):
                         self.testcase_failtrace_dict[testcase_name] = None
                 else:
                     self.temp_json["stack_exception"]= ""
-
 
     def check_call_report(self, item, nextitem):
         """


### PR DESCRIPTION
Whenever errors like name error, attribute error, composite error etc happening in the setup stage testcase will not come to call stage which causing
1: testcase_status becoming unknown because we were not added testcase and testcase_status in testcase_dict due to plugin code skipping this particular case.

Proposed changes:
   Added the case for setup failure where I have added the testcase_status and stack_exception in the retest_data.json

Test Result for - Empty stack_exception  and testcase_status ==‘unkown’  in retest_data.json

Reproduced the bug by inserting simple name error which causes the failure of testcase in the setup stage .
when testcase execution broke in setup stage stack exception is empty and testcase_status marked unknown because plugin code skipping this particular case.

all.log
http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20230112-022616_p73820/all.log
retest_data.json
http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20230112-022616_p73820/retest_data.json


Test Result for - modified changes

all.log
http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20230112-023618_p78586/all.log

retest_data.json
http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20230112-023618_p78586/retest_data.json