### PR TITLE
Enable LSAN/ASAN

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -343,7 +343,7 @@ def pytest_configure(config):
     CafyLog.mongomode=config.option.mongo_mode
     CafyLog.giso_dir = config.option.giso_dir
     script_list = config.option.file_or_dir
-    collection_list = eval(config.option.collection)
+    collection_list = config.option.collection
     # register additional markers
     config.addinivalue_line("markers", "Future(name): mark test that are planned for future")
     config.addinivalue_line("markers", "Feature(name): mark feature of a testcase")
@@ -823,7 +823,9 @@ class EmailReport(object):
         self.model_coverage_report={}
         self.collection_manager = None
         self.collection_report = {'model_coverage':None,'collector_lsan':None,'collector_asan':None,'collector_yang':None}
-        self.collection = collection_list
+        self.collection = None
+        if collection_list:
+            self.collection = eval(collection_list)
 
     def _sendemail(self):
         print("\nSending Summary Email to %s" % self.email_addr_list)

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1220,6 +1220,9 @@ class EmailReport(object):
         if report.when == 'setup':
             self.log.set_testcase(testcase_name)
             self.log.title("Start test:  %s" %(testcase_name))
+            if self.lsan:
+               self.collection_manager.connect()
+               self.collection_manager.configure()
             #Notify testcase_name to handshake server
             #If config.debug_enable is False, the reg_dict is empty, So u want to skip talking to handshake server
             if self.reg_dict:
@@ -1340,9 +1343,7 @@ class EmailReport(object):
                 self.model_coverage_report[testcase_name]=CafyLog.model_tracker_dict
                 CafyLog.model_tracker_dict={}
             if self.lsan:
-               self.log.info(self.collection_manager)
-               self.collection_manager.configure()
-
+               self.collection_manager.disconnect()
             self.log.title("Finish test: %s (%s)" %(testcase_name,status))
             self.log.info("="*80)
 

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -48,6 +48,7 @@ from logger.cafylog import CafyLog
 from topology.topo_mgr.topo_mgr import Topology
 from utils.cafyexception  import CafyException
 from utils.confest import Call_config
+from utils.collectors.collection_config import config
 from debug import DebugLibrary
 import pluggy
 import _pytest
@@ -1201,11 +1202,12 @@ class EmailReport(object):
                     except Exception as e:
                         continue
         return method_list
-
+ 
     @pytest.fixture(scope='module', autouse=True)
     def enable_lsan(self, request):
         if self.lsan:
            topo_file = CafyLog.topology_file
+           config.get_collection_config()
            collection_config_file = os.path.join(CafyLog.work_dir, 'collection_config.json')
            self.collection_manager = collection_config.setup(topo_file,collection_config_file)
         yield
@@ -1338,6 +1340,7 @@ class EmailReport(object):
                 self.model_coverage_report[testcase_name]=CafyLog.model_tracker_dict
                 CafyLog.model_tracker_dict={}
             if self.lsan:
+               self.log.info(self.collection_manager)
                self.collection_manager.configure()
 
             self.log.title("Finish test: %s (%s)" %(testcase_name,status))

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1386,6 +1386,7 @@ class EmailReport(object):
                 self.model_coverage_report[testcase_name]=CafyLog.model_tracker_dict
                 CafyLog.model_tracker_dict={}
             if self.collection:
+               self.collection_manager.deconfigure()
                self.collection_manager.disconnect()
             self.log.title("Finish test: %s (%s)" %(testcase_name,status))
             self.log.info("="*80)

--- a/cafy_pytest/resources/mail_template.html
+++ b/cafy_pytest/resources/mail_template.html
@@ -231,7 +231,7 @@
       </tbody>
     </table>
 
-    <h3></h3>
+    <h3>Debug Collection</h3>
     <table class="table table-bordered">
       <col width="30%">
       <tbody>

--- a/cafy_pytest/resources/mail_template.html
+++ b/cafy_pytest/resources/mail_template.html
@@ -231,6 +231,30 @@
       </tbody>
     </table>
 
+    <h3></h3>
+    <table class="table table-bordered">
+      <col width="30%">
+      <tbody>
+      <tr>
+        <td>Model coverage</td>
+        <td>{{report.collection_report_dict.model_coverage}}</td>
+      </tr>
+      <tr>
+        <td>Collector lsan</td>
+        <td>{{report.collection_report_dict.collector_lsan}}</td>
+      </tr>
+      <tr>
+        <td>Collector asan</td>
+        <td>{{report.collection_report_dict.collector_asan}}</td>
+      </tr>
+
+      <tr>
+        <td>Collector yang</td>
+        <td>{{report.collection_report_dict.collector_yang}}</td>
+      </tr>
+      </tbody>
+    </table>
+
     <!-- Detailed Report -->
 
     {{ detailed_header(report) }}


### PR DESCRIPTION
Feature:
enable_collection using  pytest fixture function which run in the starting of the setup of
testcases at the module level
if --collection args passed along with pytest cmd
       eg: --collection = ['lsan','debug','asan','yang','collection-config']
then
       1: Generate collection config based on the pytest args passed by user
       2: get the topology file
       3: call collection setup by passing topology file and collection config list
       4: collection_setup.setup return collection_manager object which can be used for
          4.1: collection_manager connect
          4.2: collection_manager configure
          4.3: collection_manager dconfigure
          4.4:  collection_manager disconnect

#Test 1:
When —collection args is not given
pytest /tmp/cafykit/cafy/cafykit/test/utils/test_sample.py -T /auto/cafy/infra/cafykit/testbed/POD/PSI/NCS5500/F3B-NCS5500-FIX-POD7.json

[test1.log](https://wwwin-github.cisco.com/cafy/cafykit/files/17046/test1.log)

#Test 2:
When --collection “[‘lsan’,'debug','yang','collection-config']"
pytest /tmp/cafykit/cafy/cafykit/test/utils/test_sample.py -T /auto/cafy/infra/cafykit/testbed/POD/PSI/NCS5500/F3B-NCS5500-FIX-POD7.json --collection "['lsan','debug','yang','collection-config']"

[test2.log](https://wwwin-github.cisco.com/cafy/cafykit/files/17047/test2.log)

#Test3
[test3.log](https://github.com/cafykit/cafy-pytest/files/10576881/test3.log)


Email 
Report:
<img width="524" alt="Screenshot 2023-02-03 at 1 39 15 PM" src="https://user-images.githubusercontent.com/17371750/216546459-1bb5284c-0ac4-4e79-997b-0dfb162b2be6.png">


