### PR TITLE
updating retest data

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1298,7 +1298,12 @@ class EmailReport(object):
                     self.log.info('Analyzer is not invoked as testcase failed in setup')
             status = "unknown"
             if testcase_name in self.testcase_dict:
-                status = self.testcase_dict[testcase_name].status
+                # if error occur during module teardown then marking status as failed and adding stack_exception
+                if report.longrepr:
+                    status = 'failed'
+                    self.temp_json["stack_exception"] = str(report.longrepr)
+                else:
+                    status = self.testcase_dict[testcase_name].status
             try:
                 if status != "passed" :
                     self.temp_json["name"] = testcase_name


### PR DESCRIPTION
If something get errored in teardown module of testcase then below things happening:
1: in allure log its marking status of last testcase of module as failed/errored even if last testcase of module passed
2: in terminal report its marking status of last testcase of module as passed
Retest_data getting updated using terminal report testcase status based on fail/pass

To get the stack_exception data in retest data json for the above case -
1. extracting the stack exception in teardown if its failed during teardown module
2. updating into last Testcase of module in order to handle above mismatch case



Testing
Reproduced Error: inserted error(nameerror in teradown module)
retest_data.json empty
<img width="1314" alt="t1" src="https://user-images.githubusercontent.com/17371750/223444046-551aaba9-0f77-49aa-bb5c-87ad5347fc5d.png">


Testing after changes:
<img width="1320" alt="t2" src="https://user-images.githubusercontent.com/17371750/223444068-1c472d62-92d9-4cd1-b1dc-bffee73aba1c.png">



