### PR TITLE
updating debug collector call

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -826,6 +826,7 @@ class EmailReport(object):
         self.collection_manager = None
         self.collection_report = {'model_coverage':None,'collector_lsan':None,'collector_asan':None,'collector_yang':None}
         self.collection = collection_list
+        self.debug_collector = False
 
     def _sendemail(self):
         print("\nSending Summary Email to %s" % self.email_addr_list)
@@ -1587,7 +1588,8 @@ class EmailReport(object):
 
                                 headers = {'content-type': 'application/json'}
 
-                                if len(collector_actual_obj_dict_list) > 0 and report.when!='setup':
+                                if len(collector_actual_obj_dict_list) > 0 and report.when=='setup' and self.debug_collector == False:
+                                    self.debug_collector = True
                                     params = {"testcase_name": testcase_name, "class_name": base_class_name,
                                               "inherited_classes": inherited_classes,
                                               "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1596,17 +1596,19 @@ class EmailReport(object):
                                               "failed_attr": collector_failed_attribute_list,
                                               "debug_server_name": CafyLog.debug_server,
                                               "exception_name": collector_exception_name_list}
-                                    if report.when=='setup' and self.debug_collector == False:
-                                        self.debug_collector = True
+                                    if report.when == 'setup':
+                                        if hasattr(node.parent, 'cls') and self.debug_collector == False:
+                                            self.debug_collector = True
+                                            response = self.invoke_reg_on_failed_testcase(params, headers)
+                                            if response is not None and response.status_code == 200:
+                                               if response.text:
+                                                   self.log.info("Debug Collector logs: %s" % response.text)
+                                    elif report.when == 'call':
                                         response = self.invoke_reg_on_failed_testcase(params, headers)
                                         if response is not None and response.status_code == 200:
                                             if response.text:
                                                 self.log.info("Debug Collector logs: %s" % response.text)
-                                    else:
-                                        response = self.invoke_reg_on_failed_testcase(params, headers)
-                                        if response is not None and response.status_code == 200:
-                                            if response.text:
-                                                self.log.info("Debug Collector logs: %s" % response.text)
+
 
                                 if len(rc_actual_obj_dict_list) > 0:
                                     params = {"testcase_name": testcase_name, "class_name": base_class_name,

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1588,8 +1588,7 @@ class EmailReport(object):
 
                                 headers = {'content-type': 'application/json'}
 
-                                if len(collector_actual_obj_dict_list) > 0 and report.when=='setup' and self.debug_collector == False:
-                                    self.debug_collector = True
+                                if len(collector_actual_obj_dict_list) > 0:
                                     params = {"testcase_name": testcase_name, "class_name": base_class_name,
                                               "inherited_classes": inherited_classes,
                                               "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,
@@ -1597,10 +1596,17 @@ class EmailReport(object):
                                               "failed_attr": collector_failed_attribute_list,
                                               "debug_server_name": CafyLog.debug_server,
                                               "exception_name": collector_exception_name_list}
-                                    response = self.invoke_reg_on_failed_testcase(params, headers)
-                                    if response is not None and response.status_code == 200:
-                                        if response.text:
-                                            self.log.info("Debug Collector logs: %s" % response.text)
+                                    if report.when=='setup' and self.debug_collector == False:
+                                        self.debug_collector = True
+                                        response = self.invoke_reg_on_failed_testcase(params, headers)
+                                        if response is not None and response.status_code == 200:
+                                            if response.text:
+                                                self.log.info("Debug Collector logs: %s" % response.text)
+                                    else:
+                                        response = self.invoke_reg_on_failed_testcase(params, headers)
+                                        if response is not None and response.status_code == 200:
+                                            if response.text:
+                                                self.log.info("Debug Collector logs: %s" % response.text)
 
                                 if len(rc_actual_obj_dict_list) > 0:
                                     params = {"testcase_name": testcase_name, "class_name": base_class_name,


### PR DESCRIPTION
Problem: when there is Cafy Base exception get raised , Debug collector Not getting called.
                 It should get called atleast once
Solution: added debug_collector flag and calling debug collector once in all the below case
                case1:  when there is Cafy Base exception get raised in module setup
                case2:  when there is Cafy Base exception get raised in class setup
                case3:  when there is Cafy Base exception get raised in method  setup
                case4:  when there is Cafy Base exception get raised in combination of module, class and method setup
                
                
Testing:
Tested by manually rasing cafy base exception error in all the above cases:
Logs
 Case1: when there is Cafy Base exception get raised in module setup
        http://allure.cisco.com/ws/pasverma-bgl/test_d_20230412-133525_p29586/all.log


 Case2:  when there is Cafy Base exception get raised in class setup
         http://allure.cisco.com/ws/pasverma-bgl/test_d_20230412-133918_p29725/all.log


Case 3: when there is Cafy Base exception get raised in method  setup
          http://allure.cisco.com/ws/pasverma-bgl/test_d_20230412-134320_p29942/all.log


case4:  when there is Cafy Base exception get raised in combination of module, class and method setup
         http://allure.cisco.com/ws/pasverma-bgl/test_d_20230412-134631_p30082/all.log



          

