### PR TITLE
Move from deprecated yaml.load() to yaml.safe_load()

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -235,7 +235,7 @@ def is_valid_cafyarg(arg):
     #if block is executed when arg is not a file,instead it is string of dict
     if not os.path.exists(arg):
         eval(arg)
-        argdict = yaml.load(arg)
+        argdict = yaml.safe_load(arg)
         CafyLog.script_args = argdict
     else:
         #else block is executed when arg is a file
@@ -253,7 +253,7 @@ def load_config_file(filename=None):
             _filename = os.path.join(
                 git_repo, "work", "pytest_cafy_config.yaml")
             with open(_filename, 'r') as stream:
-                return (yaml.load(stream))
+                return (yaml.safe_load(stream))
         except:
             return {}
 


### PR DESCRIPTION
Cafy runs hit the following warning:
```
---------------------------- Captured stderr setup -----------------------------
/auto/cafy/release/23.16.10/rhel7-23.16.10/lib/python3.6/site-packages/cafy_pytest/plugin.py:256: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return (yaml.load(stream))
/auto/cafy/release/23.16.10/rhel7-23.16.10/lib/python3.6/site-packages/cafy_pytest/plugin.py:238: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  argdict = yaml.load(arg)
```