### PR TITLE
Cafy Test Reporting: granular time accounting report at the end of CAFY runs.

### DIFF
--- a/cafy_pytest/cafy_timer.py
+++ b/cafy_pytest/cafy_timer.py
@@ -1,0 +1,125 @@
+import time
+import builtins
+import subprocess
+import pytest
+from logger.cafylog import CafyLog
+import json
+import os
+import inspect
+
+class TimeCollectorPlugin:
+    def __init__(self):
+        self.original_sleep = time.sleep
+        self.original_subprocess_run = subprocess.run
+        self.original_exec = builtins.exec
+        self.granular_time_testcase_dict = {}
+        self.test_case_name = None
+        self.start_time = None
+        self.total_execution_time = None
+    
+    def measure_sleep_time(self, duration):
+        '''
+        Method measure_sleep_time : it will measure the actual time taken testcase function during sleep
+        param duration: duration or sleep time declared in TC fucntion's
+        return : Update the graunular time at test case level
+        '''
+        start_time = time.perf_counter()
+        self.original_sleep(duration)
+        end_time = time.perf_counter()
+        elapsed_time = end_time - start_time
+        self.update_granular_time("sleep_time", elapsed_time)
+
+    def measure_subprocess_run(self, *args, **kwargs):
+        '''
+        Method measure_subprocess_run : it will measure the actual time taken by testcase function during executing subprocess run
+        param args : args
+        param kwargs : kwargs
+        return : Update the graunular time at test case level
+        '''
+        start_time = time.perf_counter()
+        result = self.original_subprocess_run(*args, **kwargs)
+        end_time = time.perf_counter()
+        elapsed_time = end_time - start_time
+        self.update_granular_time("bash_time", elapsed_time)
+        return result
+    
+    def update_granular_time(self, category, elapsed_time):
+        '''
+        Method update_granular_time : it will update the time at test case level
+        param category : category like bash time, sleep time etc.
+        param  elapsed_time : time spend during event like sleep, bash etc
+        return : Update the graunular time at test case level
+        '''
+        current_test = self.test_case_name
+        if current_test not in self.granular_time_testcase_dict:
+            self.granular_time_testcase_dict[current_test] = {category: elapsed_time}
+        else:
+            if category in self.granular_time_testcase_dict[current_test]:
+                self.granular_time_testcase_dict[current_test][category] += elapsed_time
+            else:
+                self.granular_time_testcase_dict[current_test][category] = elapsed_time
+
+    def pytest_runtest_protocol(self, item, nextitem):
+        '''
+        Method pytest_runtest_protocol : it will Monkey patch sleep , subprocess run 
+        Monkey patching used for modifying the behavior of built-in classes or functions, or adding instrumentation or logging to existing code.
+        param item : test case item
+        param  nextitem : test case nextitem
+        return : None
+        '''
+        self.start_time = time.perf_counter()
+        # Monkey patch time.sleep
+        time.sleep = self.measure_sleep_time
+        # Monkey patch subprocess.run
+        subprocess.run = self.measure_subprocess_run
+        #get class name of test case method
+        base_class_name = ""
+        if item.cls:
+            class_name = item.cls
+            base_classes = inspect.getmro(class_name)
+            base_class_name = base_classes[0].__name__
+        if base_class_name:
+            self.test_case_name = f"{base_class_name}.{item.name}"
+        else:
+            self.test_case_name = f"{item.name}"
+        return None
+    
+    def pytest_runtest_teardown(self, item, nextitem):
+        '''
+        Method pytest_runtest_call : will measure Total execution time of test case method
+        return : Update the graunular time at test case level
+        '''
+        end_time = time.perf_counter()
+        self.total_execution_time = end_time - self.start_time
+        self.update_granular_time("total_time", self.total_execution_time)
+        self.total_execution_time = None
+
+    def collect_granular_time_accouting_report(self):
+        '''
+        Method collect_granular_time_accouting_report : it will create report and save in cafy work dir
+        return : create report for time accounting in cafy work dir as granular_time_report.json
+        '''
+        path=CafyLog.work_dir
+        file_name='granular_time_report.json'
+        time_report = dict()
+        for test_case, times in self.granular_time_testcase_dict.items():
+            sleep_time = times.get("sleep_time", 0)
+            bash_time = times.get("bash_time", 0)
+            total_time = times.get("total_time",0)
+            time_report[test_case] = dict()
+            time_report[test_case]['Sleep time'] = sleep_time
+            time_report[test_case]['Bash time'] = bash_time
+            time_report[test_case]['Exec Time'] = None
+            time_report[test_case]['Config Time'] = None
+            time_report[test_case]['Inter Commands Delay Time'] = None
+            time_report[test_case]['Total Execution Time'] = total_time
+        with open(os.path.join(path, file_name), 'w') as fp:
+            json.dump(time_report,fp)
+
+    def pytest_terminal_summary(self, terminalreporter):
+        '''
+        Method pytest_terminal_summary : terminal reporting 
+        return : None
+        '''
+        self.collect_granular_time_accouting_report()
+

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -832,7 +832,6 @@ class EmailReport(object):
         self.collection_report = {'model_coverage':None,'collector_lsan':None,'collector_asan':None,'collector_yang':None}
         self.collection = collection_list
         self.debug_collector = False
-        self.plugin_sleep_time = 0
 
     def _sendemail(self):
         print("\nSending Summary Email to %s" % self.email_addr_list)
@@ -1738,9 +1737,7 @@ class EmailReport(object):
                             if message["collector_status"] == True:
                                 return response
                             else:
-                                sleep_time = 30
-                                time.sleep(sleep_time)
-                                self.plugin_sleep_time += sleep_time
+                                time.sleep(30)
                                 waiting_time = waiting_time + 30
                                 if waiting_time > 900:
                                     poll_flag = False


### PR DESCRIPTION
**1. Feature description and need for this PR**
Cafy Test Reporting: granular time accounting report at the end of CAFY runs.
<p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">granular time accounting report at the end of CAFY runs. Main items</p><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"> </p><div class="table-wrap" style="margin: 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Category | Total time
-- | --
sleep |  
exec commands |  
configs |  
Bash commands on router |  
Inter command delay(non-sleep) |  

</div><br class="Apple-interchange-newline">

**2. Proposed changes**
1: created a separate plugin and register as TimeCollectorPlugin 
2: added new hook using monkey patching for Granular time accounting for sleep and bash command 
3: Saving the time record in cafy work dir in format of json as granular_time_report.json

**#Testing**
**tested on below script**

   
         import os
         import time
         import subprocess
         import pytest

         class TestPdb:
                  def setup_class(self):
                         print("setup")


                 def test_pdb1(self):
                       time.sleep(5)
                       i = 0
                       p = True
                       while(p == True):
                                print("yest")
                                i = i + 1
                                if i == 10:
                                   p = False
                      time.sleep(5)
                      pass

       
               def test_pdb2(self):
                     print("strted")
                     time.sleep(5)
                     time.sleep(5)
                     print("hel")
                     if True:
                          r=subprocess.run(["echo", "Hello, World!"])
                          print(r)
                     time.sleep(10)
                     subprocess.run(["echo", "Command 2"])        
                     pass

         class TestPDB2:

                def test_pdb3(self):
                      print("strted")
                      time.sleep(5)
                      time.sleep(5)
                      print("hel")
                      os.system("echo 'Hello, World!'")
                      pass


                def test_pdb4(self):
                      print("strted")
                      time.sleep(5)
                      time.sleep(5)
                      print("hel")
                      pass


Output
Created a json file which storing time
**Saving in cafy work dir as granular_time_report.json**



<img width="1341" alt="Screenshot 2023-07-06 at 6 20 16 PM" src="https://github.com/cafykit/cafy-pytest/assets/17371750/c255f3e2-7892-491a-8e16-9d8c05e68999">



