### PR TITLE
Sort out imports and fix package build metadata, including list of dependencies

### DIFF
--- a/cafy_pytest/cafy.py
+++ b/cafy_pytest/cafy.py
@@ -2,9 +2,13 @@
 Cafy Placeholder class for pytest integeration
 """
 
-from allure_commons._allure import StepContext as AllureStepContext
 import pytest
+from allure_commons._allure import StepContext as AllureStepContext
+
+# Cafykit imports
 from utils.cafyexception import CafyException
+
+
 class Cafy:
 
     class Globals: 

--- a/cafy_pytest/cafy_pdb.py
+++ b/cafy_pytest/cafy_pdb.py
@@ -1,11 +1,15 @@
-import pdb
+import io
 import os
+import pdb
 import re
 import sys
+
+from remote_pdb import RemotePdb
+
+# Cafykit imports
 from logger.cafylog import CafyLog
 from topology.topo_mgr.topo_mgr import Topology
-from remote_pdb import RemotePdb
-import io
+
 
 class OutputCapture:
     def __init__(self):
@@ -40,8 +44,8 @@ class CafyPdb(RemotePdb):
     def __init__(self, host, port,patch_stdstreams=True):
         super(CafyPdb, self).__init__(host, port,patch_stdstreams=patch_stdstreams)
         self.prompt = "(cafy-pdb)"
-        self.topology_file = globals()['CafyLog'].topology_file
-        self.testbed_object = globals()['Topology'](self.topology_file)
+        self.topology_file = CafyLog.topology_file
+        self.testbed_object = Topology(self.topology_file)
         self.custom_commands = {
             'Local': ['show_locals','feature_lib_locals'],
             'Router': ['show_routers', 'show_router_info'],

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1,56 +1,53 @@
 '''
 This plugin will cover all the cafy related plugin like email report
 '''
-import os
-import sys
-import subprocess
-import platform
-import smtplib
+
 import getpass
-import time
-import zipfile
-import shutil
-import validators
-import itertools
 import html
-import re
-import requests
-import json
 import inspect
-import yaml
-import pytest
-import allure
+import json
+import os
+import re
+import platform
+import shutil
+import smtplib
+import subprocess
+import sys
+import time
 import traceback
-from .cafy import Cafy
-
-from urllib3 import Retry
-from requests.adapters import HTTPAdapter
-
-from _pytest.terminal import TerminalReporter
-from _pytest.runner import runtestprotocol, TestReport
-#from _pytest.mark import MarkInfo
-
-from pprint import pprint, pformat
-from enum import Enum
-from tabulate import tabulate
-from shutil import copyfile
+import zipfile
+from collections import namedtuple, OrderedDict, defaultdict
 from configparser import ConfigParser
 from datetime import datetime
-from collections import namedtuple, OrderedDict, defaultdict
-from wrapt_timeout_decorator import timeout as wrapt_timeout
-
-from email.utils import COMMASPACE
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from jinja2 import Template
+from email.mime.text import MIMEText
+from email.utils import COMMASPACE
+from enum import Enum
+from shutil import copyfile
 
+import allure
+import pytest
+import requests
+import validators
+import yaml
+import _pytest
+from jinja2 import Template
+from requests.adapters import HTTPAdapter
+from tabulate import tabulate
+from urllib3 import Retry
+from _pytest.terminal import TerminalReporter
+from _pytest.runner import runtestprotocol
+
+# Cafykit imports
+from debug import DebugLibrary
 from logger.cafylog import CafyLog
 from topology.topo_mgr.topo_mgr import Topology
-from utils.cafyexception  import CafyException
-from debug import DebugLibrary
-import pluggy
-import _pytest
+from utils.cafyexception import CafyException
 from utils.collectors.confest import Config
+
+from .cafy import Cafy
+
+
 collection_setup = Config()
 #Check with CAFYKIT_HOME or GIT_REPO or CAFYAP_REPO environment is set,
 #if all are set, CAFYAP_REPO takes precedence

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -10,7 +10,9 @@ import os
 import re
 import platform
 import shutil
+import signal
 import smtplib
+import socket
 import subprocess
 import sys
 import time
@@ -46,6 +48,8 @@ from utils.cafyexception import CafyException
 from utils.collectors.confest import Config
 
 from .cafy import Cafy
+from .cafy_pdb import CafyPdb
+from .cafypdb_config import CafyPdb_Configs
 
 
 collection_setup = Config()
@@ -53,10 +57,6 @@ collection_setup = Config()
 #if all are set, CAFYAP_REPO takes precedence
 CAFY_REPO = os.environ.get("CAFYAP_REPO", None)
 setattr(pytest,"allure",allure)
-from .cafy_pdb import CafyPdb
-from .cafypdb_config import CafyPdb_Configs
-import socket
-import signal
 
 if CAFY_REPO is None:
     #If CAFYAP_REPO is not set, check if GIT_REPO or CAFYKIT_HOME is set

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,28 @@
 '''
 Created on Feb 16, 2017
-
-@author: ask-cafy@cisco.com
 '''
-# sample ./setup.py file
+
 from setuptools import setup
 
 from cafy_pytest.__version__ import __version__
-#__version__ = "0.1.0"  
 
 setup(
     name="cafy_pytest",
     packages=['cafy_pytest'],
     package_data={'cafy_pytest': ['resources/*']},
-    author='Cafy',
-    author_email='cafy-support@cisco.com',
     version=__version__,
-    license="GPLv2",
-    url='https://github.com/kuamrend/cafy-pytest',
+    url='https://github.com/cafykit/cafy-pytest',
     description='Pytest Cafy Plugin', 	
-    install_requires=['pytest>=2.3', 'jinja2'],
+    install_requires=[
+        'allure-pytest',
+        'jinja2',
+        'pytest>=2.3',
+        'PyYAML',
+        'requests',
+        'tabulate',
+        'urllib3',
+        'validators',
+    ],
     # the following makes a plugin available to pytest
     entry_points={
         'pytest11': ['cafy_pytest = cafy_pytest.plugin']

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'jinja2',
         'pytest>=2.3',
         'PyYAML',
+        'remote-pdb',
         'requests',
         'tabulate',
         'urllib3',


### PR DESCRIPTION
- Sort out imports:
  - Organise into the following groups (following https://peps.python.org/pep-0008/#imports): stdlib, 3rd party, cafykit, relative
  - Remove unused imports
- Fix `setup.py` metadata:
  - Remove incorrect/irrelevant fields (e.g. no license)
  - List all dependencies (as per 3rd party imports group)