### PR TITLE
Hybrid Run Report to show libraries of methods

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -11,7 +11,6 @@ import time
 import zipfile
 import shutil
 import validators
-import itertools
 import html
 import re
 import requests
@@ -27,17 +26,14 @@ from urllib3 import Retry
 from requests.adapters import HTTPAdapter
 
 from _pytest.terminal import TerminalReporter
-from _pytest.runner import runtestprotocol, TestReport
-#from _pytest.mark import MarkInfo
+from _pytest.runner import runtestprotocol
 
-from pprint import pprint, pformat
 from enum import Enum
 from tabulate import tabulate
 from shutil import copyfile
 from configparser import ConfigParser
 from datetime import datetime
 from collections import namedtuple, OrderedDict, defaultdict
-from wrapt_timeout_decorator import timeout as wrapt_timeout
 
 from email.utils import COMMASPACE
 from email.mime.text import MIMEText
@@ -48,7 +44,6 @@ from logger.cafylog import CafyLog
 from topology.topo_mgr.topo_mgr import Topology
 from utils.cafyexception  import CafyException
 from debug import DebugLibrary
-import pluggy
 import _pytest
 from utils.collectors.confest import Config
 collection_setup = Config()
@@ -1152,24 +1147,20 @@ class EmailReport(object):
     def get_status(self,mode):
         try:
             running_mode=mode.split('.')[0].lower()
-            status=''
-            flag=False
-            for v in self.mode_list:
-                if v in running_mode:
-                    status=v
-                    flag=True
-                    break
-            if not(flag):
-                if hasattr(CafyLog,"hybrid_mode_dict") and CafyLog.hybrid_mode_dict.get('mode',None)=='oc':
-                    status = 'oc'
-                elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='cli':
-                    status = 'cli'
-                elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='ydk':
-                    status = 'ydk'
-                elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='hybrid_ydk':
-                    status = 'ydk'
-                elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='hybrid_oc':
-                    status = 'oc'
+            for _mode in self.mode_list:
+                if running_mode.endswith(_mode):
+                    return _mode
+            status = ''
+            if hasattr(CafyLog,"hybrid_mode_dict") and CafyLog.hybrid_mode_dict.get('mode',None)=='oc':
+                status = 'oc'
+            elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='cli':
+                status = 'cli'
+            elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='ydk':
+                status = 'ydk'
+            elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='hybrid_ydk':
+                status = 'ydk'
+            elif hasattr(CafyLog,"hybrid_mode_dict") and  CafyLog.hybrid_mode_dict.get('mode',None)=='hybrid_oc':
+                status = 'oc'
             return status
         except Exception as e:
             return e
@@ -1203,7 +1194,7 @@ class EmailReport(object):
     """
     def get_method(self):
         method_list=[]
-        if hasattr(CafyLog,"hybrid_mode_dict") and CafyLog.hybrid_mode_dict.get('cls',None):
+        if hasattr(CafyLog,"hybrid_mode_dict") and CafyLog.hybrid_mode_dict.get('cls'):
             for cls in CafyLog.hybrid_mode_dict['cls']:
                 for name, method in inspect.getmembers(cls, inspect.isfunction):
                     try:
@@ -1375,8 +1366,12 @@ class EmailReport(object):
             mode_list=self.get_mode(method_list)
             final_status=self.get_final_status(mode_list)
             self.hybrid_mode_status_dict[testcase_name]=final_status
-            for item in range(0,len(method_list)):
-                method_mode_dict[str(method_list[item].__name__)]=mode_list[item]
+            for item in range(len(method_list)):
+                method = method_list[item]
+                module = method.__module__
+                if module not in method_mode_dict:
+                    method_mode_dict[module] = {}
+                method_mode_dict[module][method.__name__] = mode_list[item]
             self.report_dump[testcase_name]={}
             self.report_dump[testcase_name]['method_mode']=method_mode_dict
             self.report_dump[testcase_name]['final_status']=final_status


### PR DESCRIPTION
- Hybrid Report only shows method names and their mode. User is not able to figure out exactly which library was used for that method. This PR adds library/module name in the report
- Bug in deriving mode from method's qualname fixed.
- Removed unused imports


Testcase Mode Report with this PR: http://allure.cisco.com/auto/tftp-aj-sjc/cafy/branch/cafykit/work/archive/syslog_test_cli_20230706-235935_p28236/testcase_mode.json

<img width="404" alt="image" src="https://github.com/cafykit/cafy-pytest/assets/53624128/49c39517-14d7-41cb-9a59-b5acecd62a5a">

Testcase Mode Report without this PR: http://allure.cisco.com/auto/tftp-aj-sjc/cafy/cafykit/work/archive/syslog_test_ydk_20230706-155041_p4262/testcase_mode.json

<img width="495" alt="image" src="https://github.com/cafykit/cafy-pytest/assets/53624128/5a3eb882-1822-4f6d-a928-9c27a6830097">
