### PR TITLE
add 'start of step' and 'end of step' log banner for cafy steps

### DIFF
--- a/cafy_pytest/cafy.py
+++ b/cafy_pytest/cafy.py
@@ -7,6 +7,8 @@ from allure_commons._allure import StepContext as AllureStepContext
 
 # Cafykit imports
 from utils.cafyexception import CafyException
+from logger.cafylog import CafyLog
+log = CafyLog("cafy_pytest_step")
 
 
 class Cafy:
@@ -49,8 +51,10 @@ class Cafy:
             super().__init__(title, params)
             self.blocking = blocking
             self.logger = logger
+            self.title=title
 
         def __enter__(self):
+            log.title(f" Start of step: {self.title}")
             super().__enter__()
 
         def __exit__(self, exc_type, exc_val, exc_tb):
@@ -62,7 +66,7 @@ class Cafy:
                         exc_type=exc_type,
                         exc_tb=exc_tb))
                     Cafy.RunInfo.active_exceptions.append(exc_val)
-
+            log.title(f" Finish of step: {self.title}")
             return not self.blocking
 
         


### PR DESCRIPTION
If a step is created using "cafy.step", then the log banner for start_of_step and end_of_Step will be printed in the logs
allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/reports/index.html

```(private_env) shreyash@sjc-ads-1448:cafy-pytest$ pytest -s $GIT_REPO/test/utils/test_allure.py
Virtual Env: /ws/shreyash-sjc/private_env
Complete Log Location: /ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/all.log
Registration Id: None
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.6.7, pytest-4.2.0, py-1.10.0, pluggy-0.8.1
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /ws/shreyash-sjc/cafyinfra/cafykit/test, inifile: pytest.ini
plugins: repeat-0.9.1, random-order-1.0.4, ordering-0.6, cov-2.5.1, cafy-pytest-0.1.0, allure-pytest-2.6.1
collected 7 items                                                                                                                                                                                                         

../../cafyinfra/cafykit/test/utils/test_allure.py -Title----2023-08-29T13-53-07.305[MainThread][cafy]> Start test:  TestSections.test_inline_step
-Title----2023-08-29T13-53-07.306[MainThread][cafy_pytest_step]>  Start of step: First step
hi from 1st step
-Title----2023-08-29T13-53-07.306[MainThread][cafy_pytest_step]>  Finish of step: First step
-Title----2023-08-29T13-53-07.306[MainThread][cafy_pytest_step]>  Start of step: Second step
hi from 2nd step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Finish of step: Second step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Start of step: Third step
hi from 3rd step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Finish of step: Third step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Start of step: Fourth step
hi from 4th step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Finish of step: Fourth step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Start of step: Fifth step
hi from 5th step
-Title----2023-08-29T13-53-07.307[MainThread][cafy_pytest_step]>  Finish of step: Fifth step
-Title----2023-08-29T13-53-07.308[MainThread][cafy_pytest_step]>  Start of step: Sixth step
hi from 6th step
-Title----2023-08-29T13-53-07.308[MainThread][cafy_pytest_step]>  Finish of step: Sixth step
.-Info-----2023-08-29T13-53-07.309[MainThread][cafy]> Teardown module for testcase TestSections.test_inline_step
-Title----2023-08-29T13-53-07.329[MainThread][cafy]> Finish test: TestSections.test_inline_step (passed)
-Info-----2023-08-29T13-53-07.329[MainThread][cafy]> ================================================================================
-Title----2023-08-29T13-53-07.330[MainThread][cafy]> Start test:  TestSections.test_nested_steps[2]
X-Info-----2023-08-29T13-53-07.331[MainThread][cafy]> Teardown module for testcase TestSections.test_nested_steps[2]
-Title----2023-08-29T13-53-07.347[MainThread][cafy]> Finish test: TestSections.test_nested_steps[2] (xpassed)
-Info-----2023-08-29T13-53-07.347[MainThread][cafy]> ================================================================================
-Title----2023-08-29T13-53-07.349[MainThread][cafy]> Start test:  TestSections.test_nested_steps[-1]
x-Info-----2023-08-29T13-53-07.376[MainThread][cafy]> Teardown module for testcase TestSections.test_nested_steps[-1]
-Title----2023-08-29T13-53-07.392[MainThread][cafy]> Finish test: TestSections.test_nested_steps[-1] (xfailed)
-Info-----2023-08-29T13-53-07.392[MainThread][cafy]> ================================================================================
-Title----2023-08-29T13-53-07.394[MainThread][cafy]> Start test:  TestSections.test_case3
Hi from test_case3, 1st step
x-Info-----2023-08-29T13-53-07.400[MainThread][cafy]> Teardown module for testcase TestSections.test_case3
-Title----2023-08-29T13-53-07.419[MainThread][cafy]> Finish test: TestSections.test_case3 (xfailed)
-Info-----2023-08-29T13-53-07.419[MainThread][cafy]> ================================================================================
-Title----2023-08-29T13-53-07.420[MainThread][cafy]> Start test:  TestSections.test_case4
Hi from test_case4, 1st step
oh yes! This exception was expected
Hi from test_case4, 3rd step
Hi from test_case4, 4th step
.-Info-----2023-08-29T13-53-07.421[MainThread][cafy]> Teardown module for testcase TestSections.test_case4
-Title----2023-08-29T13-53-07.434[MainThread][cafy]> Finish test: TestSections.test_case4 (passed)
-Info-----2023-08-29T13-53-07.435[MainThread][cafy]> ================================================================================
s-Title----2023-08-29T13-53-07.436[MainThread][cafy]> Start test:  TestSections.test_case5
-Info-----2023-08-29T13-53-07.437[MainThread][cafy]> Teardown module for testcase TestSections.test_case5
-Title----2023-08-29T13-53-07.448[MainThread][cafy]> Finish test: TestSections.test_case5 (skipped)
-Info-----2023-08-29T13-53-07.448[MainThread][cafy]> ================================================================================
-Title----2023-08-29T13-53-07.449[MainThread][cafy]> Start test:  TestSections.test_case6
Hi from test_case6, 1st step
Hi from test_case6, 2nd step
Hi from test_case6 3rd step
Hi from test_case6, 4th step
Hi from test_case6, 5th step
.-Info-----2023-08-29T13-53-07.450[MainThread][cafy]> Teardown module for testcase TestSections.test_case6
-Title----2023-08-29T13-53-07.467[MainThread][cafy]> Finish test: TestSections.test_case6 (passed)
-Info-----2023-08-29T13-53-07.467[MainThread][cafy]> ================================================================================
-Info-----2023-08-29T13-53-07.467[MainThread][cafy]> Test data generated at /ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/testdata.json
Report successfully generated to /ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/reports
-Info-----2023-08-29T13-53-11.144[MainThread][cafy]> Report: allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/reports/index.html



 TestCase Summary Status Table
+------------------------------------+----------+
| Testcase_name                      | Status   |
+====================================+==========+
| TestSections.test_inline_step      | passed   |
+------------------------------------+----------+
| TestSections.test_nested_steps[2]  | xpassed  |
+------------------------------------+----------+
| TestSections.test_nested_steps[-1] | xfailed  |
+------------------------------------+----------+
| TestSections.test_case3            | xfailed  |
+------------------------------------+----------+
| TestSections.test_case4            | passed   |
+------------------------------------+----------+
| TestSections.test_case5            | skipped  |
+------------------------------------+----------+
| TestSections.test_case6            | passed   |
+------------------------------------+----------+
Results: /ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962
Reports: allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_allure_20230829-135307_p3628962/reports/index.html

Sending Summary Email to ['shreyash@cisco.com']