### PR TITLE
GTA for time.sleep, set and get level commands

### DIFF
--- a/cafy_pytest/cafy_gta.py
+++ b/cafy_pytest/cafy_gta.py
@@ -8,12 +8,10 @@ import os
 import inspect
 from jinja2 import Template
 
-
 class TimeCollectorPlugin:
     def __init__(self):
         self.original_sleep = time.sleep
         self.original_subprocess_run = subprocess.run
-        self.original_exec = builtins.exec
         self.granular_time_testcase_dict = dict()
         self.test_case_name = None
         self.start_time = None
@@ -31,22 +29,38 @@ class TimeCollectorPlugin:
         elapsed_time = '%.2f' % (end_time - start_time)
         self.update_granular_time("sleep_time", elapsed_time)
 
-    def update_granular_time(self, category, elapsed_time):
+    def measure_subprocess_run(self, *args, **kwargs):
         '''
-        Method update_granular_time : it will update the time at test case level
-        param category : category like bash time, sleep time etc.
-        param  elapsed_time : time spend during event like sleep, bash etc
+        Method measure_subprocess_run : it will measure the actual time taken by testcase function during executing subprocess run
+        param args : args
+        param kwargs : kwargs
         return : Update the graunular time at test case level
         '''
-        current_test = self.test_case_name
-        if current_test not in self.granular_time_testcase_dict:
-            self.granular_time_testcase_dict[current_test] = {category: dict()}
-            if category == "sleep_time":
-                self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] = float(elapsed_time)
-        else:
-            if category in self.granular_time_testcase_dict[current_test]:
-               if category == "sleep_time":
-                   self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] += float(elapsed_time)
+        start_time = time.perf_counter()
+        # Capture the command
+        command = args[0] if args else None
+        process = self.original_subprocess_run(*args, **kwargs)
+        end_time = time.perf_counter()
+        elapsed_time = '%.2f' % (end_time - start_time)
+        self.update_granular_time("bash_time", elapsed_time, command)
+
+    def patch_subprocess(self):
+        '''
+        Method patch_subprocess : it will Monkey patch subprocess gfor bash commands.
+        Monkey patching used for modifying the behavior of built-in classes or functions, or adding instrumentation or logging to existing code.
+        param item : test case item
+        param  nextitem : test case nextitem
+        return : None
+        '''
+        # Monkey patch subprocess.run
+        subprocess.run = self.measure_subprocess_run
+
+    def unpatch_subprocess(self):
+        '''
+        Method unpatch_subprocess : it will Restore the original subprocess functions
+        '''
+        # Restore the original subprocess functions
+        subprocess.run = self.original_subprocess_run
 
     def pytest_runtest_protocol(self, item, nextitem):
         '''
@@ -59,6 +73,10 @@ class TimeCollectorPlugin:
         self.start_time = time.perf_counter()
         # Monkey patch time.sleep
         time.sleep = self.measure_sleep_time
+
+        #Monkey patch subprocess
+        self.patch_subprocess()
+
         #get class name of test case method
         base_class_name = ""
         if item.cls:
@@ -70,6 +88,30 @@ class TimeCollectorPlugin:
         else:
             self.test_case_name = f"{item.name}"
         return None
+
+    def update_granular_time(self, category, elapsed_time, command = None):
+        '''
+        Method update_granular_time : it will update the time at test case level
+        param category : category like bash time, sleep time etc.
+        param  elapsed_time : time spend during event like sleep, bash etc
+        return : Update the graunular time at test case level
+        '''
+        current_test = self.test_case_name
+        if current_test not in self.granular_time_testcase_dict:
+            self.granular_time_testcase_dict[current_test] = dict()
+
+        if category not in self.granular_time_testcase_dict[current_test]:
+            self.granular_time_testcase_dict[current_test][category] = dict()
+            if category == "sleep_time":
+                self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] = float(elapsed_time)
+            elif category == "bash_time" and command:
+                self.granular_time_testcase_dict[current_test][category][str(command)] = elapsed_time
+        else:
+            if category == "sleep_time":
+                    self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] += float(elapsed_time)
+            elif category == "bash_time" and command:
+                if str(command) not in self.granular_time_testcase_dict[current_test][category]:
+                    self.granular_time_testcase_dict[current_test][category][str(command)] = elapsed_time
 
     def pytest_runtest_teardown(self, item, nextitem):
         '''
@@ -91,9 +133,10 @@ class TimeCollectorPlugin:
         for test_case, times in self.granular_time_testcase_dict.items():
             sleep_time = times.get("sleep_time", 0)
             total_time = times.get("total_time",0)
+            bash_time = times.get("bash_time",0)
             time_report[test_case] = dict()
             time_report[test_case]['Sleep time'] = sleep_time
-            time_report[test_case]['Bash time'] = None
+            time_report[test_case]['Bash time'] = bash_time
             time_report[test_case]['Exec Time'] = None
             time_report[test_case]['Config Time'] = None
             time_report[test_case]['Get level command Time'] = None
@@ -101,7 +144,12 @@ class TimeCollectorPlugin:
             time_report[test_case]['Inter Commands Delay Time'] = None
             time_report[test_case]['Total Execution Time'] = total_time
         self.granular_time_testcase_dict = time_report
-        
+
+
+    def cleanup(self):
+        # Restore the original subprocess functions when done
+        self.unpatch_subprocess()
+
     def pytest_terminal_summary(self, terminalreporter):
         '''
         Method pytest_terminal_summary : terminal reporting 
@@ -121,3 +169,4 @@ class TimeCollectorPlugin:
         # Write the HTML content to the output file
         with open(html_file_path, 'w') as html_file:
             html_file.write(html_content)
+        self.cleanup()

--- a/cafy_pytest/cafy_gta.py
+++ b/cafy_pytest/cafy_gta.py
@@ -1,0 +1,123 @@
+import time
+import builtins
+import subprocess
+import pytest
+from logger.cafylog import CafyLog
+import json
+import os
+import inspect
+from jinja2 import Template
+
+
+class TimeCollectorPlugin:
+    def __init__(self):
+        self.original_sleep = time.sleep
+        self.original_subprocess_run = subprocess.run
+        self.original_exec = builtins.exec
+        self.granular_time_testcase_dict = dict()
+        self.test_case_name = None
+        self.start_time = None
+        self.total_execution_time = None
+
+    def measure_sleep_time(self, duration):
+        '''
+        Method measure_sleep_time : it will measure the actual time taken by testcase method during sleep
+        param duration: duration or sleep time declared in TC fucntion's
+        return : Update the graunular time at test case level
+        '''
+        start_time = time.perf_counter()
+        self.original_sleep(duration)
+        end_time = time.perf_counter()
+        elapsed_time = '%.2f' % (end_time - start_time)
+        self.update_granular_time("sleep_time", elapsed_time)
+
+    def update_granular_time(self, category, elapsed_time):
+        '''
+        Method update_granular_time : it will update the time at test case level
+        param category : category like bash time, sleep time etc.
+        param  elapsed_time : time spend during event like sleep, bash etc
+        return : Update the graunular time at test case level
+        '''
+        current_test = self.test_case_name
+        if current_test not in self.granular_time_testcase_dict:
+            self.granular_time_testcase_dict[current_test] = {category: dict()}
+            if category == "sleep_time":
+                self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] = float(elapsed_time)
+        else:
+            if category in self.granular_time_testcase_dict[current_test]:
+               if category == "sleep_time":
+                   self.granular_time_testcase_dict[current_test][category]["total_sleep_time"] += float(elapsed_time)
+
+    def pytest_runtest_protocol(self, item, nextitem):
+        '''
+        Method pytest_runtest_protocol : it will Monkey patch sleep , subprocess run etc
+        Monkey patching used for modifying the behavior of built-in classes or functions, or adding instrumentation or logging to existing code.
+        param item : test case item
+        param  nextitem : test case nextitem
+        return : None
+        '''
+        self.start_time = time.perf_counter()
+        # Monkey patch time.sleep
+        time.sleep = self.measure_sleep_time
+        #get class name of test case method
+        base_class_name = ""
+        if item.cls:
+            class_name = item.cls
+            base_classes = inspect.getmro(class_name)
+            base_class_name = base_classes[0].__name__
+        if base_class_name:
+            self.test_case_name = f"{base_class_name}.{item.name}"
+        else:
+            self.test_case_name = f"{item.name}"
+        return None
+
+    def pytest_runtest_teardown(self, item, nextitem):
+        '''
+        Method pytest_runtest_call : will measure Total execution time of test case method
+        return : Update the graunular time at test case level
+        '''
+        end_time = time.perf_counter()
+        self.total_execution_time ='%.2f' % (end_time - self.start_time)
+        current_test = self.test_case_name
+        self.granular_time_testcase_dict[current_test]["total_time"] = self.total_execution_time
+        self.total_execution_time = None
+
+    def collect_granular_time_accouting_report(self):
+        '''
+        Method collect_granular_time_accouting_report : it will create report and save in cafy work dir
+        return : create report for time accounting in cafy work dir as granular_time_report.json
+        '''
+        time_report = dict()
+        for test_case, times in self.granular_time_testcase_dict.items():
+            sleep_time = times.get("sleep_time", 0)
+            total_time = times.get("total_time",0)
+            time_report[test_case] = dict()
+            time_report[test_case]['Sleep time'] = sleep_time
+            time_report[test_case]['Bash time'] = None
+            time_report[test_case]['Exec Time'] = None
+            time_report[test_case]['Config Time'] = None
+            time_report[test_case]['Get level command Time'] = None
+            time_report[test_case]['Set level command Time'] = None
+            time_report[test_case]['Inter Commands Delay Time'] = None
+            time_report[test_case]['Total Execution Time'] = total_time
+        self.granular_time_testcase_dict = time_report
+        
+    def pytest_terminal_summary(self, terminalreporter):
+        '''
+        Method pytest_terminal_summary : terminal reporting 
+        return : None
+        '''
+        self.collect_granular_time_accouting_report()
+        # Create a Jinja2 environment and load the HTML template
+        CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+        template_file = os.path.join(CURRENT_DIR,"resources/gta_template.html")
+        with open(template_file) as html_src:
+            html_template = html_src.read()
+        template = Template(html_template)
+        html_content = template.render(dictionary_data=self.granular_time_testcase_dict)
+        # Define the path to the output HTML file
+        path=CafyLog.work_dir
+        html_file_path = os.path.join(path, 'granular_time_report.html')
+        # Write the HTML content to the output file
+        with open(html_file_path, 'w') as html_file:
+            html_file.write(html_content)

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -48,6 +48,7 @@ from utils.cafyexception import CafyException
 from utils.collectors.confest import Config
 
 from .cafy import Cafy
+from .cafy_gta import TimeCollectorPlugin
 from .cafy_pdb import CafyPdb
 from .cafypdb_config import CafyPdb_Configs
 
@@ -558,6 +559,7 @@ def pytest_configure(config):
                                     collection_list,
                                     cafypdb)
         config.pluginmanager.register(config._email)
+        config.pluginmanager.register(TimeCollectorPlugin())
 
         #Write all.log path to terminal
         reporter = TerminalReporter(config, sys.stdout)
@@ -585,6 +587,8 @@ def pytest_unconfigure(config):
         tmp_str_text = str(tmp_text)
         with open(os.path.join(CafyLog.work_dir, "env.txt"), "w") as f:
             f.write(tmp_str_text)
+        time_collector_plugin = config.pluginmanager.get_plugin(TimeCollectorPlugin)
+        config.pluginmanager.unregister(time_collector_plugin)
     except:
         pass
 

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -16,46 +16,67 @@
         th {
             background-color: #f2f2f2;
         }
+
+        .nested {
+            margin-left: 20px;
+        }
     </style>
 </head>
 <body>
     <h1>Granular Time Accounting Report</h1>
     <table>
         <tr>
-            <th>Test Case</th>
-            <th>Total Sleep Time(sec)</th>
-            <th>Bash Time(sec)</th>
-            <th>Exec Time(sec)</th>
-            <th>Config Time(sec)</th>
-            <th>Get Level Command Time(sec)</th>
-            <th>Set Level Command Time(sec)</th>
-            <th>Inter Commands Delay Time(sec)</th>
-            <th>Total Execution Time(sec)</th>
+            <th>Testcase</th>
+            <th>Step</th>
+            <th>Sleep Time</th>̉
+            <th>Set Level Command Time</th>
+            <th>Total Time</th>
         </tr>
-        {% for key, values in dictionary_data.items() %}
-        <tr>
-            <td>{{ key }}</td>
-            <td>{{ values["Sleep time"]["total_sleep_time"] }}</td>
-            <td>
-                {% if values['Bash time'] is mapping %}
-                    <!-- Loop through the bash_time_dict and print its key-value pairs -->
-                    <ul>
-                        {% for bash_key, bash_value in values['Bash time'].items() %}
-                        <li>{{ bash_key }}: {{ bash_value }}</li>
-                        {% endfor %}
-                    </ul>
-                {% else %}
-                    {{ values['Bash time'] }}
+    {% for key, values in dictionary_data.items() %}
+            {% for step_key, step_values in values.items() %}
+                {% if 'sleep_time' in step_key %}
+                    {% for time_key, time_values in step_values.items() %}
+                        <tr>
+                            <td>{{key}}</td>
+                            <td>{{ time_key }}</td>
+                            <td>{{ time_values[0] if time_values else 'NA' }}</td>
+                            <td>NA</td>
+                            <td>NA</td>
+                        </tr>
+                        {% if time_values is iterable and time_values|length > 1 %}
+                            {% for extra_time in time_values[1:] %}
+                                <tr class="nested">
+                                    <td></td>
+                                    <td>{{ time_key }}</td>
+                                    <td>{{ extra_time }}</td>
+                                    <td>NA</td>
+                                    <td>NA</td>
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                {% elif 'bash_time' in step_key %}
+                    {% for bash_key, bash_value in step_values.items() %}
+                        <tr>
+                            <td></td>
+                            <td>{{ bash_key }}</td>
+                            <td>NA</td>
+                            <td>{{ bash_value }}</td>
+                            <td>NA</td>
+                        </tr>
+                    {% endfor %}
                 {% endif %}
-            </td>
-            <td>{{ values["Exec Time"] }}</td>
-            <td>{{ values["Config Time"] }}</td>
-            <td>{{ values["Get level command Time"] }}</td>
-            <td>{{ values["Set level command Time"] }}</td>
-            <td>{{ values["Inter Commands Delay Time"] }}</td>
-            <td>{{ values["Total Execution Time"] }}</td>
-        </tr>
-        {% endfor %}
-    </table>
+            {% endfor %}
+            <tr>
+                <td></td>
+                <td>Total</td>
+                <td>NA</td>
+                <td>NA</td>
+                <td>
+                    {{values["total_execution_time"]}}
+                </td>
+            </tr>
+    {% endfor %}
+</table>
 </body>
 </html>

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f2f2f2;
+        }
+    </style>
+</head>
+<body>
+    <h1>Granular Time Accounting Report</h1>
+    <table>
+        <tr>
+            <th>Test Case</th>
+            <th>Total Sleep Time(sec)</th>
+            <th>Bash Time(sec)</th>
+            <th>Exec Time(sec)</th>
+            <th>Config Time(sec)</th>
+            <th>Get Level Command Time(sec)</th>
+            <th>Set Level Command Time(sec)</th>
+            <th>Inter Commands Delay Time(sec)</th>
+            <th>Total Execution Time(sec)</th>
+        </tr>
+        {% for key, values in dictionary_data.items() %}
+        <tr>
+            <td>{{ key }}</td>
+            <td>{{ values["Sleep time"]["total_sleep_time"] }}</td>
+            <td>{{ values["Bash time"] }}</td>
+            <td>{{ values["Exec Time"] }}</td>
+            <td>{{ values["Config Time"] }}</td>
+            <td>{{ values["Get level command Time"] }}</td>
+            <td>{{ values["Set level command Time"] }}</td>
+            <td>{{ values["Inter Commands Delay Time"] }}</td>
+            <td>{{ values["Total Execution Time"] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -28,20 +28,23 @@
         <tr>
             <th>Testcase</th>
             <th>Step</th>
-            <th>Sleep Time</th>̉
+            <th>Sleep Time</th>
             <th>Set Level Command Time</th>
+            <th>Get Level Command Time</th>
             <th>Total Time</th>
         </tr>
     {% for key, values in dictionary_data.items() %}
-            {% for step_key, step_values in values.items() %}
-                {% if 'sleep_time' in step_key %}
+        {% for step_key, step_values in values.items() %}
+            {% if 'sleep_time' in step_key %}
+                {% if step_values is mapping %}
                     {% for time_key, time_values in step_values.items() %}
                         <tr>
                             <td>{{key}}</td>
                             <td>{{ time_key }}</td>
                             <td>{{ time_values[0] if time_values else 'NA' }}</td>
-                            <td>NA</td>
-                            <td>NA</td>
+                            <td>-</td>
+                            <td>-</td>
+                            <td>-</td>
                         </tr>
                         {% if time_values is iterable and time_values|length > 1 %}
                             {% for extra_time in time_values[1:] %}
@@ -49,34 +52,55 @@
                                     <td></td>
                                     <td>{{ time_key }}</td>
                                     <td>{{ extra_time }}</td>
-                                    <td>NA</td>
-                                    <td>NA</td>
+                                    <td>-</td>
+                                    <td>-</td>
+                                    <td>-</td>
                                 </tr>
                             {% endfor %}
                         {% endif %}
                     {% endfor %}
-                {% elif 'bash_time' in step_key %}
-                    {% for bash_key, bash_value in step_values.items() %}
-                        <tr>
-                            <td></td>
-                            <td>{{ bash_key }}</td>
-                            <td>NA</td>
-                            <td>{{ bash_value }}</td>
-                            <td>NA</td>
-                        </tr>
+                {% endif %}
+            {% elif 'set_command' in step_key %}
+                {% if step_values is mapping %}
+                    {% for set_key, set_value in step_values.items() %}
+                        {% for value in set_value %}
+                            <tr>
+                                <td></td>
+                                <td>{{ set_key }}</td>
+                                <td>-</td>
+                                <td>{{ value }}</td>
+                                <td>-</td>
+                                <td>-</td>
+                            </tr>
+                        {% endfor %}
                     {% endfor %}
                 {% endif %}
-            {% endfor %}
-            <tr>
-                <td></td>
-                <td>Total</td>
-                <td>NA</td>
-                <td>NA</td>
-                <td>
-                    {{values["total_execution_time"]}}
-                </td>
-            </tr>
+            {% elif 'get_command' in step_key %}
+                {% if step_values is mapping %}
+                    {% for get_key, get_value in step_values.items() %}
+                        {% for value in get_value %}
+                            <tr>
+                                <td></td>
+                                <td>{{ get_key }}</td>
+                                <td>-</td>
+                                <td>-</td>
+                                <td>{{ value }}</td>
+                                <td>-</td>
+                            </tr>
+                        {% endfor %}
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+        <tr>
+            <td></td>
+            <td>Total</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>{{values["total_execution_time"]}}</td>
+        </tr>
     {% endfor %}
-</table>
+    </table>
 </body>
 </html>

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -31,7 +31,8 @@
             <th>Sleep Time</th>
             <th>Set Level Command Time</th>
             <th>Get Level Command Time</th>
-            <th>Total Time</th>
+            <th>Occurrence</th>
+            <th>Total Execution Time</th>
         </tr>
     {% for key, values in dictionary_data.items() %}
         <tr>
@@ -41,61 +42,44 @@
             <td></td>
             <td></td>
             <td></td>
-            </tr>
+        </tr>
         {% for step_key, step_values in values.items() %}
-            {% if 'sleep_time' in step_key %}
-                {% if step_values is mapping %}
+            {% if step_values is mapping %}
+                {% if 'sleep_time' in step_key %}
                     {% for time_key, time_values in step_values.items() %}
                         <tr>
                             <td></td>
                             <td>{{ time_key }}</td>
-                            <td>{{ time_values[0] if time_values else 'NA' }}</td>
+                            <td>{{ time_values[0] if time_values else '-' }}</td>
                             <td>-</td>
                             <td>-</td>
+                            <td>{{ time_values[1] if time_values else '-' }}</td>
                             <td>-</td>
                         </tr>
-                        {% if time_values is iterable and time_values|length > 1 %}
-                            {% for extra_time in time_values[1:] %}
-                                <tr class="nested">
-                                    <td></td>
-                                    <td>{{ time_key }}</td>
-                                    <td>{{ extra_time }}</td>
-                                    <td>-</td>
-                                    <td>-</td>
-                                    <td>-</td>
-                                </tr>
-                            {% endfor %}
-                        {% endif %}
                     {% endfor %}
-                {% endif %}
-            {% elif 'set_command' in step_key %}
-                {% if step_values is mapping %}
+                {% elif 'set_command' in step_key %}
                     {% for set_key, set_value in step_values.items() %}
-                        {% for value in set_value %}
-                            <tr>
-                                <td></td>
-                                <td>{{ set_key }}</td>
-                                <td>-</td>
-                                <td>{{ value }}</td>
-                                <td>-</td>
-                                <td>-</td>
-                            </tr>
-                        {% endfor %}
+                        <tr>
+                            <td></td>
+                            <td>{{ set_key }}</td>
+                            <td>-</td>
+                            <td>{{ set_value[0] if set_value else '-' }}</td>
+                            <td>-</td>
+                            <td>{{ set_value[1] if set_value else '-' }}</td>
+                            <td>-</td>
+                        </tr>
                     {% endfor %}
-                {% endif %}
-            {% elif 'get_command' in step_key %}
-                {% if step_values is mapping %}
+                {% elif 'get_command' in step_key %}
                     {% for get_key, get_value in step_values.items() %}
-                        {% for value in get_value %}
-                            <tr>
-                                <td></td>
-                                <td>{{ get_key }}</td>
-                                <td>-</td>
-                                <td>-</td>
-                                <td>{{ value }}</td>
-                                <td>-</td>
-                            </tr>
-                        {% endfor %}
+                        <tr>
+                            <td></td>
+                            <td>{{ get_key }}</td>
+                            <td>-</td>
+                            <td>-</td>
+                            <td>{{ get_value[0] if get_value else '-' }}</td>
+                            <td>{{ get_value[1] if get_value else '-' }}</td>
+                            <td>-</td>
+                        </tr>
                     {% endfor %}
                 {% endif %}
             {% endif %}
@@ -103,10 +87,11 @@
         <tr>
             <td></td>
             <td>Total</td>
+            <td>{{ values["total_sleep_time"] }}</td>
+            <td>{{ values["total_set_command_time"] }}</td>
+            <td>{{ values["total_get_command_time"] }}</td>
             <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>{{values["total_execution_time"]}}</td>
+            <td>{{ values["total_time"] }}</td>
         </tr>
     {% endfor %}
     </table>

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -36,7 +36,18 @@
         <tr>
             <td>{{ key }}</td>
             <td>{{ values["Sleep time"]["total_sleep_time"] }}</td>
-            <td>{{ values["Bash time"] }}</td>
+            <td>
+                {% if values['Bash time'] is mapping %}
+                    <!-- Loop through the bash_time_dict and print its key-value pairs -->
+                    <ul>
+                        {% for bash_key, bash_value in values['Bash time'].items() %}
+                        <li>{{ bash_key }}: {{ bash_value }}</li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    {{ values['Bash time'] }}
+                {% endif %}
+            </td>
             <td>{{ values["Exec Time"] }}</td>
             <td>{{ values["Config Time"] }}</td>
             <td>{{ values["Get level command Time"] }}</td>

--- a/cafy_pytest/resources/gta_template.html
+++ b/cafy_pytest/resources/gta_template.html
@@ -34,12 +34,20 @@
             <th>Total Time</th>
         </tr>
     {% for key, values in dictionary_data.items() %}
+        <tr>
+            <td>{{key}}</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            </tr>
         {% for step_key, step_values in values.items() %}
             {% if 'sleep_time' in step_key %}
                 {% if step_values is mapping %}
                     {% for time_key, time_values in step_values.items() %}
                         <tr>
-                            <td>{{key}}</td>
+                            <td></td>
                             <td>{{ time_key }}</td>
                             <td>{{ time_values[0] if time_values else 'NA' }}</td>
                             <td>-</td>


### PR DESCRIPTION
**1. Feature description and need for this PR**

Cafy Test Reporting: Granular Time Accounting report at the end of CAFY runs.

Doc: http://cafy-web-sjc1/pages/Cafykit/Develop/granular_time_reporting

      granular time accounting report at the end of CAFY runs. Main items

                       **Category**      
                sleep time
                Exec command 
                bash command
                config
                Inter command delay
                Set level command
                Get level command

**2. Proposed changes**
1: created a separate plugin and register as TimeCollectorPlugin
2: added new hook using monkey patching for Granular time accounting for time.sleep, set and get level commands
3: Saving the time record in cafy work dir in tabular format using html template as granular_time_report.html

**3 Testing**

#Test1
**Tested on AP : pi_infra/lldp ap 
Report Html Repot page for GTA**

           http://allure.cisco.com/ws/pasverma-bgl/lldp_ap_20240210-093622_p824242/granular_time_report.html

#Test 2
**Tested on Feature lib : test/feature_lib/ntp
Report Html Report page for GTA**
     
         http://allure.cisco.com/ws/pasverma-bgl/test_ntp_20240210-111623_p939471/granular_time_report.html

        
