### PR TITLE
Invoke debug engine collection in case of failure in teardown as well.

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1630,7 +1630,7 @@ class EmailReport(object):
         """
         Method find_available_port
         :param arg: None
-        :return:  Find and return an available port on the local machine from user defined range 
+        :return:  Find and return an available port on the local machine from user defined range
         """
         start_port = 49152
         end_port = 65535
@@ -1814,12 +1814,17 @@ class EmailReport(object):
                                             response = self.invoke_reg_on_failed_testcase(params, headers)
                                             if response is not None and response.status_code == 200:
                                                if response.text:
-                                                   self.log.info("Debug Collector logs: %s" % response.text)
+                                                   self.log.info("Setup: Debug Collector logs: %s" % response.text)
                                     elif report.when == 'call':
                                         response = self.invoke_reg_on_failed_testcase(params, headers)
                                         if response is not None and response.status_code == 200:
                                             if response.text:
-                                                self.log.info("Debug Collector logs: %s" % response.text)
+                                                self.log.info("Test: Debug Collector logs: %s" % response.text)
+                                    elif report.when == 'teardown':
+                                        response = self.invoke_reg_on_failed_testcase(params, headers)
+                                        if response is not None and response.status_code == 200:
+                                            if response.text:
+                                                self.log.info("Teardown: Debug Collector logs: %s" % response.text)
 
 
                                 if len(rc_actual_obj_dict_list) > 0:
@@ -1921,7 +1926,7 @@ class EmailReport(object):
 
     def invoke_reg_on_failed_testcase(self, params, headers):
         """
-        will call debug service api to start collection 
+        will call debug service api to start collection
         :param params: failure details of testcase for given run
         :param headers: headers associated with api request call
         """


### PR DESCRIPTION
Test Code snippet

```python
from framework.ap_base import ApBase
import pytest
from utils.cafyexception import CafyException
from logger.cafylog import CafyLog
 
log = CafyLog('Test')
 

@pytest.fixture()
def fixture_1():
    log.info('Start from fixture 1.')
    yield
    log.info('End from fixture 1.')
    raise CafyException.CafyBaseException('Raising exception in fixture 1.')
 

class TestBase(ApBase):
    def setup_method(self, method):
        log.debug('Setup method.')
 
    def teardown_method(self, method):
        log.debug('Teardown method.')
 

class TestSuite1(TestBase):
    def test_1(self):
        log.info('Hello from test_1.')
        raise CafyException.CafyBaseException('Raising exception in test body.')
 

class TestSuite2(TestBase):
    def test_2(self):
        log.info('Hello from test_2.')
 
    def teardown_method(self, method):
        super(TestSuite2, self).teardown_method(method)
        raise CafyException.CafyBaseException('Raising exception in teardown method.')
 

class TestSuite3(TestBase):
    def test_3(self, fixture_1):
        log.info('Hello from test_3.')
```


Log Link - http://allure.cisco.com/ws/dhlad-sjc/cafyap/work/archive/cafy_step_20231006-113022_p12801/reports/index.html



```
In Debug Collector
Registration ID: 2023_10_06_cafy_step_ZJ1jlGiXYJJqnl-YaJg3f1f6f2a
AP base name: TestBase
AP sub class name: TestSuite1
Testcase name: test_1
Exception name(s): ['CafyBaseException']

No AP info defined in the provided zap file. AP Name: TestSuite1
No AP info defined in the provided zap file. AP Name: TestBase

========================================================================================================================
No traces to collect for AP: TestBase, for TestCase: test_1.
Please make sure that "debug_configuration" is defined under TestArguments inside the input file.
Also make sure that your AP (TestBase) is defined properly inside the "AP" dictionary.
For more info, please check: "https://wwwin-github.cisco.com/cafy/cafykit/wiki/Enabling-&-Using-Debug-Collection-Infra"
========================================================================================================================


######################################################################################################################################################

In Debug Collector
Registration ID: 2023_10_06_cafy_step_ZJ1jlGiXYJJqnl-YaJg3f1f6f2a
AP base name: TestBase
AP sub class name: TestSuite2
Testcase name: test_2
Exception name(s): ['CafyBaseException']

No AP info defined in the provided zap file. AP Name: TestSuite2
No AP info defined in the provided zap file. AP Name: TestBase

========================================================================================================================
No traces to collect for AP: TestBase, for TestCase: test_2.
Please make sure that "debug_configuration" is defined under TestArguments inside the input file.
Also make sure that your AP (TestBase) is defined properly inside the "AP" dictionary.
For more info, please check: "https://wwwin-github.cisco.com/cafy/cafykit/wiki/Enabling-&-Using-Debug-Collection-Infra"
========================================================================================================================


######################################################################################################################################################

In Debug Collector
Registration ID: 2023_10_06_cafy_step_ZJ1jlGiXYJJqnl-YaJg3f1f6f2a
AP base name: TestBase
AP sub class name: TestSuite3
Testcase name: test_3
Exception name(s): ['CafyBaseException']

No AP info defined in the provided zap file. AP Name: TestSuite3
No AP info defined in the provided zap file. AP Name: TestBase

========================================================================================================================
No traces to collect for AP: TestBase, for TestCase: test_3.
Please make sure that "debug_configuration" is defined under TestArguments inside the input file.
Also make sure that your AP (TestBase) is defined properly inside the "AP" dictionary.
For more info, please check: "https://wwwin-github.cisco.com/cafy/cafykit/wiki/Enabling-&-Using-Debug-Collection-Infra"
========================================================================================================================


