### PR TITLE
Fix for Cafy execution email report (pass/fail) doesn't match with the email result summary  and allure log

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1326,6 +1326,7 @@ class EmailReport(object):
                 if report.longrepr:
                     status = 'failed'
                     self.temp_json["stack_exception"] = str(report.longrepr)
+                    self.testcase_dict[testcase_name].status = 'failed'
                 else:
                     status = self.testcase_dict[testcase_name].status
             try:
@@ -2352,18 +2353,21 @@ class CafyReportData(object):
             self.git_commit_id = None
         self.archive = CafyLog.work_dir
         # summary result
-        passed_list = self.terminalreporter.getreports('passed')
-        failed_list = self.terminalreporter.getreports('failed')
-        skipped_list = self.terminalreporter.getreports('skipped')
-        xpassed_list = self.terminalreporter.getreports('xpassed')
-        xfailed_list = self.terminalreporter.getreports('xfailed')
-
-        # total_tc_list = self.terminalreporter.getreports('')
-        self.passed = len(passed_list)
-        self.failed = len(failed_list)
-        self.skipped = len(skipped_list)
-        self.xpassed = len(xpassed_list)
-        self.xfailed = len(xfailed_list)
+        status_lists = {
+            'passed': [],
+            'failed': [],
+            'skipped': [],
+            'xpassed': [],
+            'xfailed': []
+        }
+        for v in self.testcase_dict.values():
+            if v.status in status_lists:
+                status_lists[v.status].append(v.status)
+        self.passed = len(status_lists['passed'])
+        self.failed = len(status_lists['failed'])
+        self.skipped = len(status_lists['skipped'])
+        self.xpassed = len(status_lists['xpassed'])
+        self.xfailed = len(status_lists['xfailed'])
         self.total = self.passed + self.failed + self.skipped + self.xpassed + self.xfailed
         if self.terminalreporter.config.option.mail_if_fail is True and self.total == self.passed and self.total != 0:
             self.terminalreporter.config._email.no_email = True


### PR DESCRIPTION
Problem statement
  1. Cafy execution email report (pass/fail) doesn't match with the email result summary  and allure log.
  2. When testcase is failed in teardown method, email report states all "pass" while testcase is actually failed.
 TZ : https://techzone.cisco.com/t5/IOS-XR-PI-CQE-INFRA-Eng/Cafy-execution-email-report-pass-fail-doesn-t-match-AP-result/td-p/11331905
 
Solution
 1. When testcase failed in teardown method , failed status is not getting updated in the testcase_status dict
 2. Added the logic to capture the status when testcase failed in teardown methods

Testing:
    I have reproduced the error using testscript where it get failed in teardown method and tested

Logs:
 Allure Log
<img width="1789" alt="Screenshot 2024-02-20 at 10 36 17 AM" src="https://github.com/cafykit/cafy-pytest/assets/17371750/bc40c622-09d1-4db0-bb79-6804f826b735">

Email Report

   
<img width="1094" alt="Screenshot 2024-02-20 at 10 29 24 AM" src="https://github.com/cafykit/cafy-pytest/assets/17371750/58b5fdcf-9248-4813-b1a2-7c43e64f7028">
