### PR TITLE
pytest_ fix

### DIFF
--- a/cafy_pytest/cafy_gta.py
+++ b/cafy_pytest/cafy_gta.py
@@ -95,8 +95,12 @@ class TimeCollectorPlugin:
                 for method_name, method in inspect.getmembers(class_obj, inspect.isfunction):
                     # Check if the attribute is callable and its name starts with 'set'
                     if callable(method) and method_name.startswith('set') or method_name.startswith('get') :
-                        original_method = getattr(class_obj, method_name)
-                        setattr(class_obj, method_name, self.measure_time_for_set_or_get_methods(original_method,class_name))
+                        #skipping appyling timer on setup method of testclass
+                        if method_name == 'setup_method':
+                            continue
+                        else:
+                            original_method = getattr(class_obj, method_name)
+                            setattr(class_obj, method_name, self.measure_time_for_set_or_get_methods(original_method,class_name))
         setattr(item.cls, '_decorated', True)
 
     def pytest_runtest_protocol(self, item, nextitem):


### PR DESCRIPTION
Problem:
When applying timer on setup_method of testclass it causing below issue
args = (<test.utils.cydiff.test_cydiff.TestYangComparator object at 0x7f0caf85f290>, <bound method TestYangComparator.test_expected_mismatch of <test.utils.cydiff.test_cydiff.TestYangComparator object at 0x7f0caf85f290>>)
kwargs = {}, start_time = 36302958.82439036

    @functools.wraps(method)
    def wrapper(*args, **kwargs):
        start_time = time.perf_counter()
>       result = method(*args, **kwargs)
E       TypeError: TestYangComparator.setup_method() takes 1 positional argument but 2 were given

/auto/cafy/release/24.09.13/rhel8-24.09.13/lib/python3.11/site-packages/cafy_pytest/cafy_gta.py:46: TypeError

RC:
setup_method should have two arg self and method like below
def setup_method(self, method):
but due to inconsistent arg passing in setup_method like somewhere passed only self, and somewhere passed both as self, method
Ex:1 where only self passed as arg:
https://wwwin-github.cisco.com/cafy/cafyap/blob/56b3981ba2b5c8632628fcd09e9de32dfa20e9db/platform/syspsv/syspsv_snake.py#L3066
it will failed here

Ex2 : where both self, method as arg passed
https://wwwin-github.cisco.com/cafy/cafyap/blob/11babc168c08c28731c69dc73b8e3e7643990e01/sample/sample_ap.py#L108
it will appy wrapper here and testcase pass

so when appyling wrapper on setup_method of testclass it is the expected signature for setup_method when used in the context of pytest.

Solution:
Skipping applying wrapper on setup_method of testclass
we are not capturing time for setup_method and class currrenlty

