### PR TITLE
added fix

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1118,10 +1118,12 @@ class EmailReport(object):
             except:
                 exc_info = sys.exc_info()
                 einfo = _pytest._code.code.ExceptionInfo.from_current()
-                call.excinfo = einfo
+                if hasattr(call, 'einfo'):
+                    call.excinfo = einfo
                 repr = einfo.getrepr(style="line")
                 result = report.get_result()
-                report.exc_info = exc_info
+                if hasattr(report, 'exc_info'):
+                    report.exc_info = exc_info
                 result.outcome = "failed"
                 result.longrepr = repr
                 report.force_result(result)


### PR DESCRIPTION
**Problem:** DHCP AP's  python 311 latest webrun errored out  
**DDTS :** CSCwn09334 

**Reason of Failure:**
The error message encountering, AttributeError: 'Result' object has no attribute 'exc_info', related to the  compatibility of plugin  code to handle missing attributes  in python311 env. 
Error stack_exception E   utils.cafyexception.CafyException.CompositeError: Composite Error: is not compatible to handle in python311 env

**Resolution:**
Added logic to handle the error

**Testing:
Reproduced Error:**
  -Title----2024-11-07T01-20-35.689[MainThread][cafy]> Start test:  TestRelayV6TgenScale.test_relay_v6_scale

INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/cafy_pytest-0.1.0-py3.11.egg/cafy_pytest/plugin.py", line 1118, in pytest_runtest_makereport
INTERNALERROR>     raise CafyException.CompositeError(elist)
INTERNALERROR> utils.cafyexception.CafyException.CompositeError: Composite Error: 
INTERNALERROR>     /auto/cafy-sjc/pasverma/cafyap/ip_infra/ip_dhcp_infra/ip_dhcp_infra_base.py:597:CafyBaseException(DHCP ipv6 bind status is not in BOUND state)
INTERNALERROR> 
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/main.py", line 283, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/main.py", line 337, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 122, in _multicall
INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/logging.py", line 803, in pytest_runtestloop
INTERNALERROR>     return (yield)  # Run all the tests.
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 122, in _multicall
INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/terminal.py", line 673, in pytest_runtestloop
INTERNALERROR>     result = yield
INTERNALERROR>              ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 103, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/main.py", line 362, in pytest_runtestloop
INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 182, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_result.py", line 100, in get_result
INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     teardown.throw(outcome._exception)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/warnings.py", line 112, in pytest_runtest_protocol
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     teardown.throw(outcome._exception)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/assertion/__init__.py", line 176, in pytest_runtest_protocol
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     teardown.throw(outcome._exception)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/unittest.py", line 429, in pytest_runtest_protocol
INTERNALERROR>     res = yield
INTERNALERROR>           ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     teardown.throw(outcome._exception)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/faulthandler.py", line 88, in pytest_runtest_protocol
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 103, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/cafy_pytest-0.1.0-py3.11.egg/cafy_pytest/plugin.py", line 1504, in pytest_runtest_protocol
INTERNALERROR>     self.check_call_report(item, nextitem)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/cafy_pytest-0.1.0-py3.11.egg/cafy_pytest/plugin.py", line 1480, in check_call_report
INTERNALERROR>     reports = runtestprotocol(item, nextitem=nextitem)
INTERNALERROR>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/runner.py", line 132, in runtestprotocol
INTERNALERROR>     reports.append(call_and_report(item, "call", log))
INTERNALERROR>                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/_pytest/runner.py", line 244, in call_and_report
INTERNALERROR>     report: TestReport = ihook.pytest_runtest_makereport(item=item, call=call)
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_hooks.py", line 513, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/pluggy/_callers.py", line 156, in _multicall
INTERNALERROR>     teardown[0].send(outcome)
INTERNALERROR>   File "/auto/cafy-sjc/pasverma/cafykit/env/lib/python3.11/site-packages/cafy_pytest-0.1.0-py3.11.egg/cafy_pytest/plugin.py", line 1125, in pytest_runtest_makereport
INTERNALERROR>     report.exc_info = exc_info
INTERNALERROR>     ^^^^^^^^^^^^^^^
INTERNALERROR> AttributeError: 'Result' object has no attribute 'exc_info'


**Tested with Changes:**

(env) [pasverma@sj6-exec-03 ip_dhcp_infra]$ pytest ip_dhcp_infra_ap.py --topology-file /auto/cafy-sjc/test/bake2/PSI_F3_SFSIM_Distributed_virtual_topo.json  --test-input-file="ip_dhcp_infra_input_file.json" -k TestRelayV6TgenScale
/auto/cafy-sjc/pasverma/cafykit/lib/topology/devices/device.py:1121: DeprecationWarning: getName() is deprecated, get the name attribute instead
  thread_name = current_thread.getName()
-Info-----2024-11-07T06-08-03.061[MainThread][topo_mgr]> TGEN platform is SPIRENT, Spirent object is created
-Info-----2024-11-07T06-08-03.342[MainThread][R1]> R1: Setting default CLI handle to vty
-Info-----2024-11-07T06-08-03.343[MainThread][R1]> R1: Setting default data model handle to ydk
-Info-----2024-11-07T06-08-03.343[MainThread][R2]> R2: Setting default CLI handle to vty
-Info-----2024-11-07T06-08-03.343[MainThread][R2]> R2: Setting default data model handle to ydk
-Info-----2024-11-07T06-08-03.344[MainThread][R3]> R3: Setting default CLI handle to vty
-Info-----2024-11-07T06-08-03.344[MainThread][R3]> R3: Setting default data model handle to ydk
-Info-----2024-11-07T06-08-03.344[MainThread][linux1]> linux1: Setting default CLI handle to vty
-Warning--2024-11-07T06-08-03.344[MainThread][linux1]> linux1: No data model handles are found. Data model operations cannot be used
-Info-----2024-11-07T06-08-03.896[MainThread][cafy]> CafyLog.debug_server : sj6-bb28-01.cisco.com
Virtual Env: /auto/cafy-sjc/pasverma/cafykit/env
Complete Log Location: /auto/cafy-sjc/pasverma/cafyap/work/archive/ip_dhcp_infra_ap_20241107-060802_p1232825/all.log
CLS Enabled: 0
Debug Engine Enabled: False
Registration Id: None
=================================================================================================================== test session starts ====================================================================================================================
platform linux -- Python 3.11.4, pytest-8.3.3, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /auto/cafy-sjc/pasverma/cafyap
configfile: pytest.ini
plugins: repeat-0.9.3, random-order-1.1.1, ordering-0.6, cov-6.0.0, allure-pytest-2.13.5, cafy-pytest-0.1.0
collected 227 items / 224 deselected / 3 selected                                                                                                                                                                                                          

ip_dhcp_infra_ap.py 

-Title----2024-11-07T06-21-29.475[MainThread][cafy]> Start test:  TestRelayV6TgenScale.test_relay_v6_scale
F-Error----2024-11-07T06-32-59.330[MainThread][cafy]> stack_exception E   utils.cafyexception.CafyException.CompositeError: Composite Error: 
        /auto/cafy-sjc/pasverma/cafyap/ip_infra/ip_dhcp_infra/ip_dhcp_infra_base.py:597:CafyBaseException(DHCP ipv6 bind status is not in BOUND state)
-Fail-----2024-11-07T06-32-59.341[MainThread][None]> <ExceptionInfo DhcpVerifyError('Binding count verification failed!') tblen=37>
-Title----2024-11-07T06-33-35.632[MainThread][cafy]> Finish test: TestRelayV6TgenScale.test_relay_v6_scale (failed)
-Info-----2024-11-07T06-33-35.632[MainThread][cafy]> ================================================================================
-Title----2024-11-07T06-33-35.648[MainThread][cafy]> Start test:  TestRelayV6TgenScale.test_client_bundle_v6_scale
.-Title----2024-11-07T06-35-58.194[MainThread][cafy]> Finish test: TestRelayV6TgenScale.test_client_bundle_v6_scale (passed)
-Info-----2024-11-07T06-35-58.195[MainThread][cafy]> ================================================================================
-Title----2024-11-07T06-35-58.209[MainThread][cafy]> Start test:  TestRelayV6TgenScale.test_client_bvi_v6_scale
F-Error----2024-11-07T06-47-18.897[MainThread][cafy]> stack_exception E   utils.cafyexception.CafyException.CompositeError: Composite Error: 
        /auto/cafy-sjc/pasverma/cafyap/ip_infra/ip_dhcp_infra/ip_dhcp_infra_base.py:763:CafyBaseException(DHCP ipv6 bind status is not in BOUND state)
-Fail-----2024-11-07T06-47-18.908[MainThread][None]> <ExceptionInfo DhcpVerifyError('Binding count verification failed!') tblen=37>
-Title----2024-11-07T06-48-42.565[MainThread][cafy]> Finish test: TestRelayV6TgenScale.test_client_bvi_v6_scale (failed)
-Info-----2024-11-07T06-48-42.565[MainThread][cafy]> ================================================================================
                                                                                                                                                                                                                              [100%]-Info-----2024-11-07T06-48-42.572[MainThread][cafy]> Test data generated at /auto/cafy-sjc/pasverma/cafyap/work/archive/ip_dhcp_infra_ap_20241107-060802_p1232825/testdata.json
Report successfully generated to /auto/cafy-sjc/pasverma/cafyap/work/archive/ip_dhcp_infra_ap_20241107-060802_p1232825/reports
-Info-----2024-11-07T06-48-56.172[MainThread][cafy]> Report: allure.cisco.com/auto/cafy-sjc/pasverma/cafyap/work/archive/ip_dhcp_infra_ap_20241107-060802_p1232825/reports/index.html

**Allure Log:**
 http://allure.cisco.com/auto/cafy-sjc/pasverma/cafyap/work/archive/ip_dhcp_infra_ap_20241107-060802_p1232825/reports/
