### PR TITLE
added fix

### DIFF
--- a/cafy_pytest/cafy.py
+++ b/cafy_pytest/cafy.py
@@ -9,7 +9,8 @@ from allure_commons._allure import StepContext as AllureStepContext
 from utils.cafyexception import CafyException
 from logger.cafylog import CafyLog
 log = CafyLog("cafy_pytest_step")
-
+import traceback
+import allure
 
 class Cafy:
 
@@ -61,10 +62,12 @@ class Cafy:
             super().__exit__(exc_type, exc_val, exc_tb)
             if not self.blocking:
                 if exc_type:
+                    full_traceback = "".join(traceback.format_exception(exc_type, exc_val, exc_tb))
                     print("Step failed here: {exc_type}:{exc_val}".format(
                         exc_val=exc_val,
                         exc_type=exc_type,
                         exc_tb=exc_tb))
+                    allure.attach(full_traceback, name=f"Exception in {self.title}", attachment_type=allure.attachment_type.TEXT)
                     Cafy.RunInfo.active_exceptions.append(exc_val)
             log.banner(f" Finish of step: {self.title}")
             return not self.blocking


### PR DESCRIPTION
Problem: Exception /traceback Error not getting captured in allure log when blocking is False when we are using pytest.cafy.step

Solution: Added Exception Logs Explicitily in allure log when blocking is False when we are using pytest.cafy.step

Reproduced Error
1 : [allure.cisco.com/auto/cafy-sjc/pasverma/cafykit/work/archive/test_sample_20250205-081333_p3950839/reports/index.html](http://allure.cisco.com/auto/cafy-sjc/pasverma/cafykit/work/archive/test_sample_20250205-081333_p3950839/reports/index.html)

Test log:

1: https://allure.cisco.com/auto/cafy-sjc/pasverma/cafykit/work/archive/test_sample_20250205-081559_p3952340/reports/index.html#suites/e8bfbab9d04b06e5d9423f2e1f7d0d66/47b2ff06131b45d/
2: https://allure.cisco.com/auto/cafy-sjc/pasverma/cafykit/work/archive/test_sample_20250205-082035_p3954644/reports/index.html#suites/e8bfbab9d04b06e5d9423f2e1f7d0d66/4bae47b2b0c02bd3/