### PR TITLE
Fix handling of determining 'work dir'

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -395,28 +395,22 @@ def pytest_configure(config):
         pid = os.getpid()
         work_dir_name = "%s_%s_p%s" % (script_name,_current_time, pid )
 
-        if not config.option.reportdir:
-            #If workdir option is set, execute the if block and if not given,
-            #execute the else block where the workdir will be set to
-            #GIT_REPO/work/archive
-            if config.option.workdir:
-                if os.path.exists(config.option.workdir):
-                    custom_workdir = config.option.workdir
-                    work_dir = custom_workdir
-                else:
-                    print('workdir path not found: {}'.format(config.option.workdir))
-                    pytest.exit('workdir path not found')
-            else:
-                if CAFY_REPO:
-                    work_dir = os.path.join(CAFY_REPO, 'work', "archive", work_dir_name)
-        else:
+        if config.option.reportdir:
             if os.path.exists(config.option.reportdir):
                 work_dir = os.path.join(config.option.reportdir, work_dir_name)
             else:
                 print('reportdir path not found: {}'.format(config.option.reportdir))
                 pytest.exit('reportdir path not found')
+        elif config.option.workdir:
+            if os.path.exists(config.option.workdir):
+                custom_workdir = config.option.workdir
+                work_dir = custom_workdir
+            else:
+                print('workdir path not found: {}'.format(config.option.workdir))
+                pytest.exit('workdir path not found')
+        else:
+            work_dir = work_dir = os.path.join(os.getcwd(), work_dir_name)
 
-        CafyLog.work_dir = work_dir
         #Set CafyLog.work_dir option for all.log
         CafyLog.work_dir = work_dir
         _setup_env()
@@ -781,13 +775,9 @@ def get_datentime():
 
 def _setup_archive_env():
     '''setup archive env'''
-    #print ('setting up env: ARCHIVE_DIR ')
     # create archive folder with 777 permision
     if not os.path.exists(CafyLog.work_dir):
         os.makedirs(CafyLog.work_dir, 0o777)
-    else:
-        pass
-        #print ('{} is already created'.format(CafyLog.work_dir))
     # setup environment variable for cafy user to add files in archive
     os.environ['ARCHIVE_DIR'] = CafyLog.work_dir
 

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -409,7 +409,7 @@ def pytest_configure(config):
                 print('workdir path not found: {}'.format(config.option.workdir))
                 pytest.exit('workdir path not found')
         else:
-            work_dir = work_dir = os.path.join(os.getcwd(), work_dir_name)
+            work_dir = os.path.join(os.path.abspath(config.option.rootdir), work_dir_name)
 
         #Set CafyLog.work_dir option for all.log
         CafyLog.work_dir = work_dir

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -385,7 +385,7 @@ def pytest_configure(config):
             script_path = script_path.split('::')[0]
         CafyLog.script_path = os.path.abspath(script_path)
 
-        script_name = os.path.basename(script_list[0]).replace('.py', '')
+        script_name = os.path.basename(script_path.rstrip("/")).replace('.py', '')
         #If someone gives the script in the format
         #moduleName::className::testcaseName to execute only a specific testcase
         if '::' in script_name:


### PR DESCRIPTION
### Problem description
- When a Cafy test is invoked with a positional arg (`config.option.file_or_dir`), some extra logic is hit in the plugin.
- Among other things (such as setting up emails), this determines the "work_dir" from either `--report-dir` or `--work-dir` args.
- If neither of these args are provided, then it defaults to `f"{CAFY_REPO}/work/archive/{work_dir_name}"`.
- This causes a failure in `_setup_archive_env()` where the dir is created because users don't have write permissions in the Cafy release directories! (it's an unhelpful place for logs to be going anyway, presumably left behind from development)

### Changes
- If neither `--work-dir` nor `--report-dir` are set then default to the pytest root directory, the rest of the logic is unchanged.
- Support getting the "script name" from a directory, e.g. `pytest foo/` (previously empty).
- Tidy up the code, remove commented out/duplicated lines, make the logic branching clearer.