### PR TITLE
Replace use of `rootdir` in `pytest_configure()` hook with `getcwd()`

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -409,7 +409,7 @@ def pytest_configure(config):
                 print('workdir path not found: {}'.format(config.option.workdir))
                 pytest.exit('workdir path not found')
         else:
-            work_dir = os.path.join(os.path.abspath(config.option.rootdir), work_dir_name)
+            work_dir = os.path.join(os.getcwd(), work_dir_name)
 
         #Set CafyLog.work_dir option for all.log
         CafyLog.work_dir = work_dir


### PR DESCRIPTION
Breakage caused by https://github.com/cafykit/cafy-pytest/pull/144 due to `config.option.rootdir` being populated *after* the `pytest_configure()` hook is called. Instead just use the cwd in the case no `--work-dir` or `--report-dir` was given.

Note that this issue is not expected to affect end-users since the code that was there before caused an error anyway (users must always pass work dir/report dir) - this just affects internal cafy testing.