### PR TITLE
Remove need for `GIT_REPO` env var

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -4,6 +4,7 @@ This plugin will cover all the cafy related plugin like email report
 
 import getpass
 import html
+import importlib.resources
 import inspect
 import json
 import os
@@ -266,9 +267,15 @@ def is_valid_cafyarg(arg):
 def load_config_file(filename=None):
     _filename = filename
     if not _filename:
-        git_repo = os.getenv("GIT_REPO", None)
-        if git_repo:
-            _filename = os.path.join(git_repo, "work", "pytest_cafy_config.yaml")
+        try:
+            with importlib.resources.open_text(
+                "cafykit", "pytest_cafy_config.yaml"
+            ) as f:
+                return yaml.safe_load(f)
+        except Exception:
+            git_repo = os.getenv("GIT_REPO", None)
+            if git_repo:
+                _filename = os.path.join(git_repo, "work", "pytest_cafy_config.yaml")
     if _filename:
         try:
             with open(_filename, 'r') as stream:

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -271,7 +271,7 @@ def load_config_file(filename=None):
     #  - cafykit/pytest_cafy_config.yaml (in the cafykit package)
     if not filename and "GIT_REPO" in os.environ:
         legacy_repo_path = os.path.join(
-            os.environ["GIT_REPO"], "work", "pytest_cafy_config.yaml"
+            os.environ["GIT_REPO"], "work/pytest_cafy_config.yaml"
         )
         if os.path.exists(legacy_repo_path):
             filename = legacy_repo_path
@@ -282,7 +282,7 @@ def load_config_file(filename=None):
             pass
         else:
             cafykit_pkg_path = os.path.join(
-                os.path.dirname(cafykit.__file__), "pytest_cafy_config.yaml"
+                os.path.dirname(cafykit.__file__), "config/pytest_cafy_config.yaml"
             )
             if os.path.exists(cafykit_pkg_path):
                 filename = cafykit_pkg_path

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -89,10 +89,6 @@ if CAFY_REPO is None:
 else:
     os.environ['CAFY_REPO'] = CAFY_REPO
 
-if not CAFY_REPO:
-    msg = "Please set the environment variable GIT_REPO or CAFYKIT_HOME or CAFYAP_REPO "
-    pytest.exit(msg)
-
 
 cafy_args = os.environ.get('CAFY_ARGS')
 if cafy_args:
@@ -271,14 +267,16 @@ def load_config_file(filename=None):
     _filename = filename
     if not _filename:
         git_repo = os.getenv("GIT_REPO", None)
-    if git_repo:
+        if git_repo:
+            _filename = os.path.join(git_repo, "work", "pytest_cafy_config.yaml")
+    if _filename:
         try:
-            _filename = os.path.join(
-                git_repo, "work", "pytest_cafy_config.yaml")
             with open(_filename, 'r') as stream:
-                return (yaml.safe_load(stream))
+                return yaml.safe_load(stream)
         except:
             return {}
+    else:
+        return {}
 
 def is_jsonable(val):
     try:
@@ -847,7 +845,7 @@ class EmailReport(object):
         # with single test script
         _current_time = get_datentime()
         email_report = 'email_report.html'
-        if self.CAFY_REPO:
+        if CafyLog.work_dir:
             #self.archive_name = CafyLog.work_dir + '.zip'
             #self.archive = os.path.join(CafyLog.work_dir, self.archive_name)
             self.archive = CafyLog.work_dir
@@ -2257,7 +2255,7 @@ class CafyReportData(object):
                 html_link = os.path.join(
                         os.path.sep, CafyLog.web_host, file_link)
             else:
-                if path.startswith(('/auto', '/ws')):
+                if not path or path.startswith(('/auto', '/ws')):
                     html_link = os.path.join(
                             os.path.sep, 'http://allure.cisco.com', file_link)
                 else:

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -77,17 +77,18 @@ setattr(pytest,"allure",Cafy)
 #  - CAFYKIT_HOME
 #  - GIT_REPO
 #
-# The CAFY_REPO env var is then set (also for backwards compatibility).
+# The CAFY_REPO env var is set in the latter two cases (also for backwards
+# compatibility).
 
 CAFY_REPO = os.environ.get("CAFYAP_REPO", None)
-if CAFY_REPO is None:
-    CAFY_REPO = os.environ.get("CAFYKIT_HOME", None)
-if CAFY_REPO is None:
-    CAFY_REPO = os.environ.get("GIT_REPO", None)
-if CAFY_REPO:
-    if not os.path.isdir(os.path.join(CAFY_REPO, 'lib')):
-        pytest.exit(f'Specified CAFY repo not found: {CAFY_REPO}')
-    os.environ['CAFY_REPO'] = CAFY_REPO
+if CAFY_REPO is None and "CAFYKIT_HOME" in os.environ:
+    CAFY_REPO = os.environ["CAFYKIT_HOME"]
+    os.environ["CAFY_REPO"] = CAFY_REPO
+if CAFY_REPO is None and "GIT_REPO" in os.environ:
+    CAFY_REPO = os.environ["GIT_REPO"]
+    os.environ["CAFY_REPO"] = CAFY_REPO
+    if not os.path.isdir(os.path.join(CAFY_REPO, 'work')):
+        pytest.exit(f'GIT_REPO has not been set to correct repo.')
 
 
 cafy_args = os.environ.get('CAFY_ARGS')
@@ -423,7 +424,7 @@ def pytest_configure(config):
                 print('workdir path not found: {}'.format(config.option.workdir))
                 pytest.exit('workdir path not found')
         elif CAFY_REPO:
-            work_dir = os.path.join(CAFY_REPO, work_dir_name)
+            work_dir = os.path.join(CAFY_REPO, "work", "archive", work_dir_name)
         else:
             work_dir = os.path.join(os.getcwd(), work_dir_name)
 

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -421,6 +421,8 @@ def pytest_configure(config):
             else:
                 print('workdir path not found: {}'.format(config.option.workdir))
                 pytest.exit('workdir path not found')
+        elif CAFY_REPO:
+            work_dir = os.path.join(CAFY_REPO, work_dir_name)
         else:
             work_dir = os.path.join(os.getcwd(), work_dir_name)
 
@@ -1979,7 +1981,7 @@ class EmailReport(object):
         '''this hook is the execution point of email plugin'''
         #self._generate_email_report(terminalreporter)
         self._generate_all_log_html()
-        if self.CAFY_REPO:
+        if CafyLog.work_dir:
             option = terminalreporter.config.option
             # self._create_archive(option)
             #If junitxml option is given on cmd line, this file is available

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -266,10 +266,12 @@ def is_valid_cafyarg(arg):
 def load_config_file(filename=None):
     config = {}
     # If no file path given the check the following places (in order):
-    #  - {CAFY_REPO}/work/pytest_cafy_config.yaml (for backwards compatibility)
+    #  - $GIT_REPO/work/pytest_cafy_config.yaml (for backwards compatibility)
     #  - cafykit/pytest_cafy_config.yaml (in the cafykit package)
-    if not filename and CAFY_REPO:
-        legacy_repo_path = os.path.join(CAFY_REPO, "work", "pytest_cafy_config.yaml")
+    if not filename and "GIT_REPO" in os.environ:
+        legacy_repo_path = os.path.join(
+            os.environ["GIT_REPO"], "work", "pytest_cafy_config.yaml"
+        )
         if os.path.exists(legacy_repo_path):
             filename = legacy_repo_path
     if not filename:
@@ -416,8 +418,7 @@ def pytest_configure(config):
                 pytest.exit('reportdir path not found')
         elif config.option.workdir:
             if os.path.exists(config.option.workdir):
-                custom_workdir = config.option.workdir
-                work_dir = custom_workdir
+                work_dir = config.option.workdir
             else:
                 print('workdir path not found: {}'.format(config.option.workdir))
                 pytest.exit('workdir path not found')


### PR DESCRIPTION
The current expectation is that the cafykit repo (or cafyap repo?) is provided via one of `CAFYAP_REPO`, `CAFYKIT_HOME` or `GIT_REPO` env vars, and there's a `pytest.exit()` if this does not hold. This doesn't work in the case that cafykit is just installed as a dependency, so relax the requirement.

Changes in the diff:
- Tidy up the code that handles determining `CAFY_REPO`
  - Should be no change of behaviour, with care around the exact logic staying the same (except the `pytest_cafy_config.yaml` file is no longer expected to exist in `$GIT_REPO/work/`).
- Change `load_config_file()` to fall back to looking for config file in the cafykit package
  - Config file is moved from `<repo>/work/` to `<repo>/lib/cafykit/` and included in the package.
  - Ensure tolerance around file not being found, or failure to read the file (give a warning in this case).
- Replace a couple of `if CAFY_REPO` checks with `if CafyLog.work_dir`
  - Previously `CAFY_REPO` would always have to be set, so these branches are always expected to be hit, and will continue to be.
  - The reason for the check is that the `CafyLog.work_dir` path is used within the block, so this is the correct thing to be checking so that this code still runs even if `CAFY_REPO` is not set.
- One case of treating no `CAFY_REPO` being set as the same as using a release repo (in `/ws/` or `/auto/`)

Tested alongside cafykit changes.

Should update people that if they need to set one of these env vars it will no longer be checked here.