### PR TITLE
Ensure CAFY_REPO env var is set if CAFYAP_REPO is set

### DIFF
--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -77,18 +77,18 @@ setattr(pytest,"allure",Cafy)
 #  - CAFYKIT_HOME
 #  - GIT_REPO
 #
-# The CAFY_REPO env var is set in the latter two cases (also for backwards
-# compatibility).
+# The CAFY_REPO env var is set if any of the above env vars are set (backwards
+# compatible, relied on by AP tests).
 
 CAFY_REPO = os.environ.get("CAFYAP_REPO", None)
 if CAFY_REPO is None and "CAFYKIT_HOME" in os.environ:
     CAFY_REPO = os.environ["CAFYKIT_HOME"]
-    os.environ["CAFY_REPO"] = CAFY_REPO
 if CAFY_REPO is None and "GIT_REPO" in os.environ:
     CAFY_REPO = os.environ["GIT_REPO"]
-    os.environ["CAFY_REPO"] = CAFY_REPO
     if not os.path.isdir(os.path.join(CAFY_REPO, 'work')):
         pytest.exit(f'GIT_REPO has not been set to correct repo.')
+if CAFY_REPO:
+    os.environ["CAFY_REPO"] = CAFY_REPO
 
 
 cafy_args = os.environ.get('CAFY_ARGS')


### PR DESCRIPTION
Missed an `else` when attempting fully compatible changes in https://github.com/cafykit/cafy-pytest/pull/146.

```python
#Check with CAFYKIT_HOME or GIT_REPO or CAFYAP_REPO environment is set,
#if all are set, CAFYAP_REPO takes precedence
CAFY_REPO = os.environ.get("CAFYAP_REPO", None)

## Environment variable is a string always. This code needs to be imrpoved to string as "true/false"
CLS = int(os.environ.get("CLS", 0))
cls_host = os.environ.get("CLS_HOST", None)
LOGSTASH_SERVER = os.environ.get("LOGSTASH_SERVER", None)
LOGSTASH_PORT = os.environ.get("LOGSTASH_PORT", None)
if not (LOGSTASH_PORT or LOGSTASH_SERVER) and CLS ==1 :
    CLS = 0





setattr(pytest,"allure",Cafy)

if CAFY_REPO is None:
    #If CAFYAP_REPO is not set, check if GIT_REPO or CAFYKIT_HOME is set
    #If both GIT_REPO and CAFYKIT_HOME are set, CAFYKIT_HOME takes precedence
    CAFY_REPO = os.environ.get("CAFYKIT_HOME", None)
    if CAFY_REPO:
        os.environ['CAFY_REPO'] = CAFY_REPO
    else:
        CAFY_REPO = os.environ.get("GIT_REPO", None)
        if CAFY_REPO:
            if os.path.exists(os.path.join(CAFY_REPO, 'work', 'pytest_cafy_config.yaml')):
                # CAFY_REPO variable has been set to correct repo.
                os.environ['CAFY_REPO'] = CAFY_REPO
            else:
                msg = 'GIT_REPO has not been set to correct repo.'
                pytest.exit(msg)
else:
    os.environ['CAFY_REPO'] = CAFY_REPO
```