### PR TITLE
enable debug collector

### DIFF
--- a/cafy_pytest/cafy.py
+++ b/cafy_pytest/cafy.py
@@ -21,6 +21,7 @@ class Cafy:
         current_testcase = None
         current_failures = dict()
         active_exceptions = list()
+        block_exception = list()
 
     class TestcaseStatus:
         def __init__(self,name,status,message):
@@ -69,6 +70,12 @@ class Cafy:
                         exc_tb=exc_tb))
                     allure.attach(full_traceback, name=f"Exception in {self.title}", attachment_type=allure.attachment_type.TEXT)
                     Cafy.RunInfo.active_exceptions.append(exc_val)
+                    exception_dict = {
+                        'exc_type': exc_type,
+                        'exc_value': exc_val,
+                        'exc_tb':exc_tb
+                    }
+                    Cafy.RunInfo.block_exception.append(exception_dict)
             log.banner(f" Finish of step: {self.title}")
             return not self.blocking
 
@@ -79,6 +86,7 @@ class Cafy:
 
         def __enter__(self):
             Cafy.RunInfo.active_exceptions = list()
+            Cafy.RunInfo.block_exception = list()
             Cafy.RunInfo.current_failures[Cafy.RunInfo.current_testcase] = list()
 
         def __exit__(self, exc_type, exc_val, exc_tb):
@@ -87,8 +95,9 @@ class Cafy:
                 for exc in Cafy.RunInfo.active_exceptions:
                     new_list.append(exc)
                 Cafy.RunInfo.active_exceptions = list()
+                Cafy.RunInfo.block_exception = list()
                 raise CafyException.CompositeError(new_list)
-
+            Cafy.RunInfo.block_exception = list()
             Cafy.RunInfo.current_failures[Cafy.RunInfo.current_testcase] = list()
 
     def scope(title="Cafy Scope"):

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1119,9 +1119,13 @@ class EmailReport(object):
             try:
                 elist = list()
                 #title = Cafy.RunInfo.active_exceptions.pop()
+                if Cafy.RunInfo.block_exception:
+                    result.outcome = "failed"
+                    self.exception_interact(item,call,result)
                 for exception in Cafy.RunInfo.active_exceptions:
                     elist.append(exception)
                 Cafy.RunInfo.active_exceptions = list()
+                Cafy.RunInfo.block_exception = list()
                 raise CafyException.CompositeError(elist)
             except:
                 exc_info = sys.exc_info()
@@ -1416,6 +1420,7 @@ class EmailReport(object):
                 self.model_coverage_report[testcase_name]=CafyLog.model_tracker_dict
                 CafyLog.model_tracker_dict={}
             self.log.title("Finish test: %s (%s)" %(testcase_name,status))
+            Cafy.RunInfo.block_exception = list()
             self.log.info("="*80)
 
         #The following if block is executed for @pytest.mark.xfail(run=False) and
@@ -1676,6 +1681,164 @@ class EmailReport(object):
         except Exception as e:
             self.log.info("Cafy Debugger: closing port Failed {}".format(e))
 
+    def exception_interact(self, node, call, report):
+        if report.failed:
+            if Cafy.RunInfo.block_exception:
+                CafyLog().fail(str(Cafy.RunInfo.block_exception))
+            else:
+                CafyLog().fail(str(call.excinfo))
+            if report.outcome == 'failed':
+                #If config.debug_enable is False, the reg_dict is empty, So u want to skip talking to collector server
+                if self.reg_dict:
+                    if hasattr(report, 'when'):
+                        if report.when == 'setup':
+                            test_class = node.nodeid.split('::')[1]
+                            if test_class not in self.analyzer_testcase.keys():
+                                self.analyzer_testcase.update({test_class: 1})
+                            else:
+                                self.analyzer_testcase[test_class] += 1
+                            if node.cls not in self.errored_testcase_count:
+                                self.errored_testcase_count[node.cls] = 1
+                            else:
+                                self.errored_testcase_count[node.cls]+=1
+
+                        if (node.cls in self.errored_testcase_count and self.errored_testcase_count[node.cls]==1) or report.when!='setup':
+                            testcase_name = node.name
+                            inherited_classes = []
+                            if node.cls:
+                                class_name = node.cls
+                                base_classes = inspect.getmro(class_name)
+                                for base_class in base_classes:
+                                    if base_class.__name__ not in ["ApBase", "object"]:
+                                        inherited_classes.append(base_class.__name__)
+                                index = 1
+                                if len(base_classes) == 3:
+                                    index = 0
+                                base_class_name = base_classes[index].__name__
+                                #base_class_name = base_classes[1].__name__
+                            else:
+                                base_class_name = None
+                            if "reg_id" in self.reg_dict:
+                                reg_id = self.reg_dict["reg_id"]
+                            else:
+                                reg_id = '00'
+
+                            collector_exception_name_list = []
+                            collector_actual_obj_dict_list = []
+                            collector_actual_obj_name_list = []
+                            collector_failed_attribute_list = []
+                            rc_exception_name_list = []
+                            rc_actual_obj_dict_list = []
+                            rc_actual_obj_name_list = []
+                            rc_failed_attribute_list = []
+                            exception_details = ""
+                            all_exceptions = list()
+                            
+                            if Cafy.RunInfo.block_exception:
+                                all_exceptions = Cafy.RunInfo.block_exception
+
+                            if call.excinfo:
+                                exc_type = call.excinfo.type
+                                exc_value = call.excinfo.value
+                                call_exc_dict = {
+                                    'exc_type' : exc_type,
+                                    'exc_value': exc_value
+                                }
+                                all_exceptions.append(call_exc_dict)
+
+                            for exec in all_exceptions:
+                                exception_type = exec['exc_type']
+                                try:
+                                    if issubclass(exception_type, CafyException.CafyBaseException):
+                                        exception_details += exec['exc_value'].get_exception_details()
+                                        self.log.exception_details = exception_details
+                                except:
+                                    self.log.info("Error happened while getting exception details for retest")
+
+                                # Check if the exception encountered is not an instance of CafyBaseException, then don't invoke collector service
+                                if not issubclass(exception_type, CafyException.CafyBaseException):
+                                    self.log.info(
+                                        "The encountered exception '%s' is not an instance of CafyBaseException, It could be a python built-in exception."
+                                        " Therefore collector service will not be invoked " \
+                                        % exception_type.__name__)
+                                else:
+                                    exception_name = exec['exc_type'].__name__
+                                    if exception_name == "CompositeError":
+                                        for curr_exception in exec['exc_value'].exceptions:
+                                            exception_type = type(curr_exception).__name__
+                                            call_dict = {}
+                                            if 'VerificationError' in exception_type:
+                                                exception_name = 'VerificationError'
+                                                if hasattr(curr_exception, 'verifier'):
+                                                    call_dict['verifier'] = curr_exception.verifier
+                                                if hasattr(curr_exception, 'columns'):
+                                                    call_dict['columns'] = curr_exception.columns
+                                            elif 'TgenCheckTrafficError'in exception_type:
+                                                exception_name = 'TgenCheckTrafficError'
+                                                if hasattr(curr_exception, 'item_stats'):
+                                                    call_dict['item_stats'] = curr_exception.item_stats
+                                                if hasattr(curr_exception, 'flow_stats'):
+                                                    call_dict['flow_stats'] = curr_exception.flow_stats
+                                            else:
+                                                exception_name = 'None'
+                                            self.handle_all_exceptions(base_class_name, call_dict, exception_name,
+                                                                    collector_exception_name_list, collector_actual_obj_dict_list,
+                                                                    collector_actual_obj_name_list, collector_failed_attribute_list,
+                                                                    rc_exception_name_list, rc_actual_obj_dict_list,
+                                                                    rc_actual_obj_name_list,
+                                                                    rc_failed_attribute_list)
+                                    else:
+                                        call_dict = exec['exc_value'].__dict__
+                                        self.handle_all_exceptions(base_class_name, call_dict, exception_name,
+                                                                collector_exception_name_list, collector_actual_obj_dict_list,
+                                                                collector_actual_obj_name_list, collector_failed_attribute_list,
+                                                                rc_exception_name_list, rc_actual_obj_dict_list,
+                                                                rc_actual_obj_name_list,
+                                                                rc_failed_attribute_list)
+
+                            headers = {'content-type': 'application/json'}
+
+                            if len(collector_actual_obj_dict_list) > 0:
+                                params = {"testcase_name": testcase_name, "class_name": base_class_name,
+                                            "inherited_classes": inherited_classes,
+                                            "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,
+                                            "actual_obj_dict": collector_actual_obj_dict_list,
+                                            "failed_attr": collector_failed_attribute_list,
+                                            "debug_server_name": CafyLog.debug_server,
+                                            "exception_name": collector_exception_name_list}
+                                if report.when == 'setup':
+                                    if hasattr(node.parent, 'cls') and self.debug_collector == False:
+                                        self.debug_collector = True
+                                        response = self.invoke_reg_on_failed_testcase(params, headers)
+                                        if response is not None and response.status_code == 200:
+                                            if response.text:
+                                                self.log.info("Setup: Debug Collector logs: %s" % response.text)
+                                elif report.when == 'call':
+                                    response = self.invoke_reg_on_failed_testcase(params, headers)
+                                    if response is not None and response.status_code == 200:
+                                        if response.text:
+                                            self.log.info("Test: Debug Collector logs: %s" % response.text)
+                                elif report.when == 'teardown':
+                                    response = self.invoke_reg_on_failed_testcase(params, headers)
+                                    if response is not None and response.status_code == 200:
+                                        if response.text:
+                                            self.log.info("Teardown: Debug Collector logs: %s" % response.text)
+
+
+                            if len(rc_actual_obj_dict_list) > 0:
+                                params = {"testcase_name": testcase_name, "class_name": base_class_name,
+                                            "inherited_classes": inherited_classes,
+                                            "reg_dict": self.reg_dict, "actual_obj_name": rc_actual_obj_name_list,
+                                            "actual_obj_dict": rc_actual_obj_dict_list, "failed_attr": rc_failed_attribute_list,
+                                            "debug_server_name": CafyLog.debug_server,
+                                            "exception_name": rc_exception_name_list}
+                                response = self.invoke_rc_on_failed_testcase(params, headers)
+                                if response is not None and response.status_code == 200:
+                                    if response.json().get("traffic_logs"):
+                                        self.rclog.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
+                    else:
+                        self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
+
     def pytest_exception_interact(self, node, call, report):
         '''
         if cafypdb enabled using --cafypdb then on exception or error init Custom pdb class
@@ -1708,149 +1871,7 @@ class EmailReport(object):
                 self.log.info("Cafy Debugger: Promt Failed {}".format(e))
             finally:
                 self.close_port(self.available_port)
-
-        if report.failed:
-            CafyLog().fail(str(call.excinfo))
-            if report.outcome == 'failed':
-                #If config.debug_enable is False, the reg_dict is empty, So u want to skip talking to collector server
-                if self.reg_dict:
-                    if hasattr(report, 'when'):
-                        if report.when == 'setup':
-                            test_class = node.nodeid.split('::')[1]
-                            if test_class not in self.analyzer_testcase.keys():
-                                self.analyzer_testcase.update({test_class: 1})
-                            else:
-                                self.analyzer_testcase[test_class] += 1
-                            if node.cls not in self.errored_testcase_count:
-                                self.errored_testcase_count[node.cls] = 1
-                            else:
-                                self.errored_testcase_count[node.cls]+=1
-
-                        if (node.cls in self.errored_testcase_count and self.errored_testcase_count[node.cls]==1) or report.when!='setup':
-                            testcase_name = node.name
-                            inherited_classes = []
-                            if node.cls:
-                                class_name = node.cls
-                                base_classes = inspect.getmro(class_name)
-                                for base_class in base_classes:
-                                    if base_class.__name__ not in ["ApBase", "object"]:
-                                        inherited_classes.append(base_class.__name__)
-                                index = 1
-                                if len(base_classes) == 3:
-                                    index = 0
-                                base_class_name = base_classes[index].__name__
-
-
-                                #base_class_name = base_classes[1].__name__
-                            else:
-                                base_class_name = None
-                            if "reg_id" in self.reg_dict:
-                                reg_id = self.reg_dict["reg_id"]
-                            else:
-                                reg_id = '00'
-
-                            exception_type = call.excinfo.type
-                            try:
-                                if issubclass(exception_type, CafyException.CafyBaseException):
-                                    exception_details = call.excinfo.value.get_exception_details()
-                                    self.log.exception_details = exception_details
-                            except:
-                                self.log.info("Error happened while getting exception details for retest")
-
-                            # Check if the exception encountered is not an instance of CafyBaseException, then don't invoke collector service
-                            if not issubclass(exception_type, CafyException.CafyBaseException):
-                                self.log.info(
-                                    "The encountered exception '%s' is not an instance of CafyBaseException, It could be a python built-in exception."
-                                    " Therefore collector service will not be invoked " \
-                                    % exception_type.__name__)
-
-                            else:
-                                collector_exception_name_list = []
-                                collector_actual_obj_dict_list = []
-                                collector_actual_obj_name_list = []
-                                collector_failed_attribute_list = []
-                                rc_exception_name_list = []
-                                rc_actual_obj_dict_list = []
-                                rc_actual_obj_name_list = []
-                                rc_failed_attribute_list = []
-
-                                exception_name = exception_type.__name__
-                                if exception_name == "CompositeError":
-                                    for curr_exception in call.excinfo.value.exceptions:
-                                        exception_type = type(curr_exception).__name__
-                                        call_dict = {}
-                                        if 'VerificationError' in exception_type:
-                                            exception_name = 'VerificationError'
-                                            if hasattr(curr_exception, 'verifier'):
-                                                call_dict['verifier'] = curr_exception.verifier
-                                            if hasattr(curr_exception, 'columns'):
-                                                call_dict['columns'] = curr_exception.columns
-                                        elif 'TgenCheckTrafficError'in exception_type:
-                                            exception_name = 'TgenCheckTrafficError'
-                                            if hasattr(curr_exception, 'item_stats'):
-                                                call_dict['item_stats'] = curr_exception.item_stats
-                                            if hasattr(curr_exception, 'flow_stats'):
-                                                call_dict['flow_stats'] = curr_exception.flow_stats
-                                        else:
-                                            exception_name = 'None'
-
-                                        self.handle_all_exceptions(base_class_name, call_dict, exception_name,
-                                                                   collector_exception_name_list, collector_actual_obj_dict_list,
-                                                                   collector_actual_obj_name_list, collector_failed_attribute_list,
-                                                                   rc_exception_name_list, rc_actual_obj_dict_list,
-                                                                   rc_actual_obj_name_list,
-                                                                   rc_failed_attribute_list)
-                                else:
-                                    call_dict = call.excinfo.value.__dict__
-                                    self.handle_all_exceptions(base_class_name, call_dict, exception_name,
-                                                               collector_exception_name_list, collector_actual_obj_dict_list,
-                                                               collector_actual_obj_name_list, collector_failed_attribute_list,
-                                                               rc_exception_name_list, rc_actual_obj_dict_list,
-                                                               rc_actual_obj_name_list,
-                                                               rc_failed_attribute_list)
-
-                                headers = {'content-type': 'application/json'}
-
-                                if len(collector_actual_obj_dict_list) > 0:
-                                    params = {"testcase_name": testcase_name, "class_name": base_class_name,
-                                              "inherited_classes": inherited_classes,
-                                              "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,
-                                              "actual_obj_dict": collector_actual_obj_dict_list,
-                                              "failed_attr": collector_failed_attribute_list,
-                                              "debug_server_name": CafyLog.debug_server,
-                                              "exception_name": collector_exception_name_list}
-                                    if report.when == 'setup':
-                                        if hasattr(node.parent, 'cls') and self.debug_collector == False:
-                                            self.debug_collector = True
-                                            response = self.invoke_reg_on_failed_testcase(params, headers)
-                                            if response is not None and response.status_code == 200:
-                                               if response.text:
-                                                   self.log.info("Setup: Debug Collector logs: %s" % response.text)
-                                    elif report.when == 'call':
-                                        response = self.invoke_reg_on_failed_testcase(params, headers)
-                                        if response is not None and response.status_code == 200:
-                                            if response.text:
-                                                self.log.info("Test: Debug Collector logs: %s" % response.text)
-                                    elif report.when == 'teardown':
-                                        response = self.invoke_reg_on_failed_testcase(params, headers)
-                                        if response is not None and response.status_code == 200:
-                                            if response.text:
-                                                self.log.info("Teardown: Debug Collector logs: %s" % response.text)
-
-
-                                if len(rc_actual_obj_dict_list) > 0:
-                                    params = {"testcase_name": testcase_name, "class_name": base_class_name,
-                                              "inherited_classes": inherited_classes,
-                                              "reg_dict": self.reg_dict, "actual_obj_name": rc_actual_obj_name_list,
-                                              "actual_obj_dict": rc_actual_obj_dict_list, "failed_attr": rc_failed_attribute_list,
-                                              "debug_server_name": CafyLog.debug_server,
-                                              "exception_name": rc_exception_name_list}
-                                    response = self.invoke_rc_on_failed_testcase(params, headers)
-                                    if response is not None and response.status_code == 200:
-                                        if response.json().get("traffic_logs"):
-                                            self.rclog.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
-                    else:
-                        self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
+        self.exception_interact(node,call,report)
 
     def handle_all_exceptions(self, base_class_name, call_dict, exception_name,
                               collector_exception_name_list,

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -1120,7 +1120,7 @@ class EmailReport(object):
                 elist = list()
                 #title = Cafy.RunInfo.active_exceptions.pop()
                 if Cafy.RunInfo.block_exception:
-                    result.outcome = "failed"
+                    CafyLog().fail(str(Cafy.RunInfo.block_exception))
                     self.exception_interact(item,call,result)
                 for exception in Cafy.RunInfo.active_exceptions:
                     elist.append(exception)
@@ -1682,162 +1682,156 @@ class EmailReport(object):
             self.log.info("Cafy Debugger: closing port Failed {}".format(e))
 
     def exception_interact(self, node, call, report):
-        if report.failed:
-            if Cafy.RunInfo.block_exception:
-                CafyLog().fail(str(Cafy.RunInfo.block_exception))
-            else:
-                CafyLog().fail(str(call.excinfo))
-            if report.outcome == 'failed':
-                #If config.debug_enable is False, the reg_dict is empty, So u want to skip talking to collector server
-                if self.reg_dict:
-                    if hasattr(report, 'when'):
-                        if report.when == 'setup':
-                            test_class = node.nodeid.split('::')[1]
-                            if test_class not in self.analyzer_testcase.keys():
-                                self.analyzer_testcase.update({test_class: 1})
-                            else:
-                                self.analyzer_testcase[test_class] += 1
-                            if node.cls not in self.errored_testcase_count:
-                                self.errored_testcase_count[node.cls] = 1
-                            else:
-                                self.errored_testcase_count[node.cls]+=1
-
-                        if (node.cls in self.errored_testcase_count and self.errored_testcase_count[node.cls]==1) or report.when!='setup':
-                            testcase_name = node.name
-                            inherited_classes = []
-                            if node.cls:
-                                class_name = node.cls
-                                base_classes = inspect.getmro(class_name)
-                                for base_class in base_classes:
-                                    if base_class.__name__ not in ["ApBase", "object"]:
-                                        inherited_classes.append(base_class.__name__)
-                                index = 1
-                                if len(base_classes) == 3:
-                                    index = 0
-                                base_class_name = base_classes[index].__name__
-                                #base_class_name = base_classes[1].__name__
-                            else:
-                                base_class_name = None
-                            if "reg_id" in self.reg_dict:
-                                reg_id = self.reg_dict["reg_id"]
-                            else:
-                                reg_id = '00'
-
-                            collector_exception_name_list = []
-                            collector_actual_obj_dict_list = []
-                            collector_actual_obj_name_list = []
-                            collector_failed_attribute_list = []
-                            rc_exception_name_list = []
-                            rc_actual_obj_dict_list = []
-                            rc_actual_obj_name_list = []
-                            rc_failed_attribute_list = []
-                            exception_details = ""
-                            all_exceptions = list()
-                            
-                            if Cafy.RunInfo.block_exception:
-                                all_exceptions = Cafy.RunInfo.block_exception
-
-                            if call.excinfo:
-                                exc_type = call.excinfo.type
-                                exc_value = call.excinfo.value
-                                call_exc_dict = {
-                                    'exc_type' : exc_type,
-                                    'exc_value': exc_value
-                                }
-                                all_exceptions.append(call_exc_dict)
-
-                            for exec in all_exceptions:
-                                exception_type = exec['exc_type']
-                                try:
-                                    if issubclass(exception_type, CafyException.CafyBaseException):
-                                        exception_details += exec['exc_value'].get_exception_details()
-                                        self.log.exception_details = exception_details
-                                except:
-                                    self.log.info("Error happened while getting exception details for retest")
-
-                                # Check if the exception encountered is not an instance of CafyBaseException, then don't invoke collector service
-                                if not issubclass(exception_type, CafyException.CafyBaseException):
-                                    self.log.info(
-                                        "The encountered exception '%s' is not an instance of CafyBaseException, It could be a python built-in exception."
-                                        " Therefore collector service will not be invoked " \
-                                        % exception_type.__name__)
-                                else:
-                                    exception_name = exec['exc_type'].__name__
-                                    if exception_name == "CompositeError":
-                                        for curr_exception in exec['exc_value'].exceptions:
-                                            exception_type = type(curr_exception).__name__
-                                            call_dict = {}
-                                            if 'VerificationError' in exception_type:
-                                                exception_name = 'VerificationError'
-                                                if hasattr(curr_exception, 'verifier'):
-                                                    call_dict['verifier'] = curr_exception.verifier
-                                                if hasattr(curr_exception, 'columns'):
-                                                    call_dict['columns'] = curr_exception.columns
-                                            elif 'TgenCheckTrafficError'in exception_type:
-                                                exception_name = 'TgenCheckTrafficError'
-                                                if hasattr(curr_exception, 'item_stats'):
-                                                    call_dict['item_stats'] = curr_exception.item_stats
-                                                if hasattr(curr_exception, 'flow_stats'):
-                                                    call_dict['flow_stats'] = curr_exception.flow_stats
-                                            else:
-                                                exception_name = 'None'
-                                            self.handle_all_exceptions(base_class_name, call_dict, exception_name,
-                                                                    collector_exception_name_list, collector_actual_obj_dict_list,
-                                                                    collector_actual_obj_name_list, collector_failed_attribute_list,
-                                                                    rc_exception_name_list, rc_actual_obj_dict_list,
-                                                                    rc_actual_obj_name_list,
-                                                                    rc_failed_attribute_list)
-                                    else:
-                                        call_dict = exec['exc_value'].__dict__
-                                        self.handle_all_exceptions(base_class_name, call_dict, exception_name,
-                                                                collector_exception_name_list, collector_actual_obj_dict_list,
-                                                                collector_actual_obj_name_list, collector_failed_attribute_list,
-                                                                rc_exception_name_list, rc_actual_obj_dict_list,
-                                                                rc_actual_obj_name_list,
-                                                                rc_failed_attribute_list)
-
-                            headers = {'content-type': 'application/json'}
-
-                            if len(collector_actual_obj_dict_list) > 0:
-                                params = {"testcase_name": testcase_name, "class_name": base_class_name,
-                                            "inherited_classes": inherited_classes,
-                                            "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,
-                                            "actual_obj_dict": collector_actual_obj_dict_list,
-                                            "failed_attr": collector_failed_attribute_list,
-                                            "debug_server_name": CafyLog.debug_server,
-                                            "exception_name": collector_exception_name_list}
-                                if report.when == 'setup':
-                                    if hasattr(node.parent, 'cls') and self.debug_collector == False:
-                                        self.debug_collector = True
-                                        response = self.invoke_reg_on_failed_testcase(params, headers)
-                                        if response is not None and response.status_code == 200:
-                                            if response.text:
-                                                self.log.info("Setup: Debug Collector logs: %s" % response.text)
-                                elif report.when == 'call':
-                                    response = self.invoke_reg_on_failed_testcase(params, headers)
-                                    if response is not None and response.status_code == 200:
-                                        if response.text:
-                                            self.log.info("Test: Debug Collector logs: %s" % response.text)
-                                elif report.when == 'teardown':
-                                    response = self.invoke_reg_on_failed_testcase(params, headers)
-                                    if response is not None and response.status_code == 200:
-                                        if response.text:
-                                            self.log.info("Teardown: Debug Collector logs: %s" % response.text)
-
-
-                            if len(rc_actual_obj_dict_list) > 0:
-                                params = {"testcase_name": testcase_name, "class_name": base_class_name,
-                                            "inherited_classes": inherited_classes,
-                                            "reg_dict": self.reg_dict, "actual_obj_name": rc_actual_obj_name_list,
-                                            "actual_obj_dict": rc_actual_obj_dict_list, "failed_attr": rc_failed_attribute_list,
-                                            "debug_server_name": CafyLog.debug_server,
-                                            "exception_name": rc_exception_name_list}
-                                response = self.invoke_rc_on_failed_testcase(params, headers)
-                                if response is not None and response.status_code == 200:
-                                    if response.json().get("traffic_logs"):
-                                        self.rclog.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
+        #If config.debug_enable is False, the reg_dict is empty, So u want to skip talking to collector server
+        if self.reg_dict:
+            if hasattr(report, 'when'):
+                if report.when == 'setup':
+                    test_class = node.nodeid.split('::')[1]
+                    if test_class not in self.analyzer_testcase.keys():
+                        self.analyzer_testcase.update({test_class: 1})
                     else:
-                        self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
+                        self.analyzer_testcase[test_class] += 1
+                    if node.cls not in self.errored_testcase_count:
+                        self.errored_testcase_count[node.cls] = 1
+                    else:
+                        self.errored_testcase_count[node.cls]+=1
+
+                if (node.cls in self.errored_testcase_count and self.errored_testcase_count[node.cls]==1) or report.when!='setup':
+                    testcase_name = node.name
+                    inherited_classes = []
+                    if node.cls:
+                        class_name = node.cls
+                        base_classes = inspect.getmro(class_name)
+                        for base_class in base_classes:
+                            if base_class.__name__ not in ["ApBase", "object"]:
+                                inherited_classes.append(base_class.__name__)
+                        index = 1
+                        if len(base_classes) == 3:
+                            index = 0
+                        base_class_name = base_classes[index].__name__
+                        #base_class_name = base_classes[1].__name__
+                    else:
+                        base_class_name = None
+                    if "reg_id" in self.reg_dict:
+                        reg_id = self.reg_dict["reg_id"]
+                    else:
+                        reg_id = '00'
+
+                    collector_exception_name_list = []
+                    collector_actual_obj_dict_list = []
+                    collector_actual_obj_name_list = []
+                    collector_failed_attribute_list = []
+                    rc_exception_name_list = []
+                    rc_actual_obj_dict_list = []
+                    rc_actual_obj_name_list = []
+                    rc_failed_attribute_list = []
+                    exception_details = ""
+                    all_exceptions = list()
+
+                    if Cafy.RunInfo.block_exception:
+                        all_exceptions = Cafy.RunInfo.block_exception
+
+                    if call.excinfo:
+                        exc_type = call.excinfo.type
+                        exc_value = call.excinfo.value
+                        call_exc_dict = {
+                            'exc_type' : exc_type,
+                            'exc_value': exc_value
+                        }
+                        all_exceptions.append(call_exc_dict)
+
+                    for exec in all_exceptions:
+                        exception_type = exec['exc_type']
+                        try:
+                            if issubclass(exception_type, CafyException.CafyBaseException):
+                                exception_details += exec['exc_value'].get_exception_details()
+                                self.log.exception_details = exception_details
+                        except:
+                            self.log.info("Error happened while getting exception details for retest")
+
+                        # Check if the exception encountered is not an instance of CafyBaseException, then don't invoke collector service
+                        if not issubclass(exception_type, CafyException.CafyBaseException):
+                            self.log.info(
+                                "The encountered exception '%s' is not an instance of CafyBaseException, It could be a python built-in exception."
+                                " Therefore collector service will not be invoked " \
+                                % exception_type.__name__)
+                        else:
+                            exception_name = exec['exc_type'].__name__
+                            if exception_name == "CompositeError":
+                                for curr_exception in exec['exc_value'].exceptions:
+                                    exception_type = type(curr_exception).__name__
+                                    call_dict = {}
+                                    if 'VerificationError' in exception_type:
+                                        exception_name = 'VerificationError'
+                                        if hasattr(curr_exception, 'verifier'):
+                                            call_dict['verifier'] = curr_exception.verifier
+                                        if hasattr(curr_exception, 'columns'):
+                                            call_dict['columns'] = curr_exception.columns
+                                    elif 'TgenCheckTrafficError'in exception_type:
+                                        exception_name = 'TgenCheckTrafficError'
+                                        if hasattr(curr_exception, 'item_stats'):
+                                            call_dict['item_stats'] = curr_exception.item_stats
+                                        if hasattr(curr_exception, 'flow_stats'):
+                                            call_dict['flow_stats'] = curr_exception.flow_stats
+                                    else:
+                                        exception_name = 'None'
+                                    self.handle_all_exceptions(base_class_name, call_dict, exception_name,
+                                                            collector_exception_name_list, collector_actual_obj_dict_list,
+                                                            collector_actual_obj_name_list, collector_failed_attribute_list,
+                                                            rc_exception_name_list, rc_actual_obj_dict_list,
+                                                            rc_actual_obj_name_list,
+                                                            rc_failed_attribute_list)
+                            else:
+                                call_dict = exec['exc_value'].__dict__
+                                self.handle_all_exceptions(base_class_name, call_dict, exception_name,
+                                                        collector_exception_name_list, collector_actual_obj_dict_list,
+                                                        collector_actual_obj_name_list, collector_failed_attribute_list,
+                                                        rc_exception_name_list, rc_actual_obj_dict_list,
+                                                        rc_actual_obj_name_list,
+                                                        rc_failed_attribute_list)
+
+                    headers = {'content-type': 'application/json'}
+
+                    if len(collector_actual_obj_dict_list) > 0:
+                        params = {"testcase_name": testcase_name, "class_name": base_class_name,
+                                    "inherited_classes": inherited_classes,
+                                    "reg_dict": self.reg_dict, "actual_obj_name": collector_actual_obj_name_list,
+                                    "actual_obj_dict": collector_actual_obj_dict_list,
+                                    "failed_attr": collector_failed_attribute_list,
+                                    "debug_server_name": CafyLog.debug_server,
+                                    "exception_name": collector_exception_name_list}
+                        if report.when == 'setup':
+                            if hasattr(node.parent, 'cls') and self.debug_collector == False:
+                                self.debug_collector = True
+                                response = self.invoke_reg_on_failed_testcase(params, headers)
+                                if response is not None and response.status_code == 200:
+                                    if response.text:
+                                        self.log.info("Setup: Debug Collector logs: %s" % response.text)
+                        elif report.when == 'call':
+                            response = self.invoke_reg_on_failed_testcase(params, headers)
+                            if response is not None and response.status_code == 200:
+                                if response.text:
+                                    self.log.info("Test: Debug Collector logs: %s" % response.text)
+                        elif report.when == 'teardown':
+                            response = self.invoke_reg_on_failed_testcase(params, headers)
+                            if response is not None and response.status_code == 200:
+                                if response.text:
+                                    self.log.info("Teardown: Debug Collector logs: %s" % response.text)
+
+
+                    if len(rc_actual_obj_dict_list) > 0:
+                        params = {"testcase_name": testcase_name, "class_name": base_class_name,
+                                    "inherited_classes": inherited_classes,
+                                    "reg_dict": self.reg_dict, "actual_obj_name": rc_actual_obj_name_list,
+                                    "actual_obj_dict": rc_actual_obj_dict_list, "failed_attr": rc_failed_attribute_list,
+                                    "debug_server_name": CafyLog.debug_server,
+                                    "exception_name": rc_exception_name_list}
+                        response = self.invoke_rc_on_failed_testcase(params, headers)
+                        if response is not None and response.status_code == 200:
+                            if response.json().get("traffic_logs"):
+                                self.rclog.info("Debug RC logs: \n%s" % response.json()["traffic_logs"])
+            else:
+                self.log.debug("Type of report obtained is %s. Debug engine is only triggered for reports of type TestReport" %type(report))
 
     def pytest_exception_interact(self, node, call, report):
         '''
@@ -1871,7 +1865,9 @@ class EmailReport(object):
                 self.log.info("Cafy Debugger: Promt Failed {}".format(e))
             finally:
                 self.close_port(self.available_port)
-        self.exception_interact(node,call,report)
+        if report.failed and report.outcome == 'failed':
+            CafyLog().fail(str(call.excinfo))
+            self.exception_interact(node,call,report)
 
     def handle_all_exceptions(self, base_class_name, call_dict, exception_name,
                               collector_exception_name_list,


### PR DESCRIPTION
**Problem Statement:**
   1: Debug Collector service is not being triggered when test cases use pytest.cafy.step with blocking=False.
   2: Debug Collector service is only invoked when exceptions occurred and pytest_exception_interaction get called.
   3: When using pytest.cafy.step(blocking=False), exceptions did not invoke the pytest_exception_interaction method, 
         and as a result, the Debug Collector service (which resides inside that method)  also not invoked.

**Solution:**
  1: Introduced a new attribute Cafy.RunInfo.block_exception, a list of dictionaries to capture exception details (exc_type, 
      exc_value, and exc_tb) within the Cafy framework (cafy.py). This list is populated when an exception occurs with 
      blocking=False.
  2: Refactored the logic for invoking Debug Collector services into a separate method exception_interact within the 
       plugin code.
  3: Modified pytest_makereport to call the exception_interact method when Cafy.RunInfo.block_exception is not empty, 
      ensuring exceptions are handled properly even when blocking=False with pytest.cafy.step failed.
  4: Enabled collective invocation of Debug Collector services at the test case level for all failed steps using 
      blocking=False with pytest.cafy.step
              
**Testing :  Test log with multiple pytest.cafy.step with blocking = False** 
platform linux -- Python 3.11.4, pytest-8.3.3, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /auto/cafy-sjc/pasverma/cafykit/test
configfile: pytest.ini
plugins: repeat-0.9.3, random-order-1.1.1, ordering-0.6, cov-6.0.0, allure-pytest-2.13.5, cafy-pytest-0.1.0
collected 2 items                                                                                                                                                                                                                                

../cafykit/test/utils/test_debug4.py -Info-----2025-04-20T23-07-49.904[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/initiate_analyzer/) to initialize analyzer
-Warning--2025-04-20T23-07-51.818[MainThread][cafy]> HTTP Status Code: 417
{"message": "Unexpected failure AttributeError(\"'NoneType' object has no attribute 'is_alive'\",)", "analyzer_status": false}
-Warning--2025-04-20T23-07-51.818[MainThread][cafy]> Analyzer failed 417
other setup part
-Title----2025-04-20T23-07-51.819[MainThread][cafy]> Start test:  TestSections.test_debug_step
-Info-----2025-04-20T23-07-51.826[MainThread][cafy]> Handshake for 2025_04_20_test_debug4_aHBolJWXlJNucWSYlZg796fcffb for TestSections.test_debug_step to registration service successful
-Info-----2025-04-20T23-07-51.826[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.826[MainThread][cafy_pytest_step]> |                   Start of step: Debugging Testcase1 Step 1                  |
-Info-----2025-04-20T23-07-51.826[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:19:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase1 Step 1                  |
-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> |                   Start of step: Debugging Testcase1 Step 2                  |
-Info-----2025-04-20T23-07-51.830[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:28:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase1 Step 2                  |
-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> |                   Start of step: Debugging Testcase1 Step 3                  |
-Info-----2025-04-20T23-07-51.832[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:38:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-07-51.834[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-07-51.834[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase1 Step 3                  |
-Info-----2025-04-20T23-07-51.834[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Fail-----2025-04-20T23-07-51.842[MainThread][None]> [{'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f347f90c0>}, {'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f34a14680>}, {'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f34a16a00>}]
-Info-----2025-04-20T23-07-51.844[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/startdebug/v1/) to start collecting
-Info-----2025-04-20T23-08-23.668[MainThread][cafy]> Test: Debug Collector logs: {"collector_status":true}

F-Error----2025-04-20T23-08-23.671[MainThread][cafy]> stack_exception E   utils.cafyexception.CafyException.CompositeError: Composite Error: 
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:19:ZeroDivisionError(division by zero)
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:28:ZeroDivisionError(division by zero)
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:38:ZeroDivisionError(division by zero)
-Info-----2025-04-20T23-08-23.671[MainThread][cafy]> Teardown module for testcase TestSections.test_debug_step
-Info-----2025-04-20T23-08-23.685[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/end_test_case/) to check analyzer status
-Info-----2025-04-20T23-08-23.698[MainThread][cafy]> result of analyzer {'status': False, 'failures': '{}'}
-Info-----2025-04-20T23-08-23.698[MainThread][cafy]> Analyzer Status is {'status': False, 'failures': '{}'}
-Title----2025-04-20T23-08-23.698[MainThread][cafy]> Finish test: TestSections.test_debug_step (failed)
-Info-----2025-04-20T23-08-23.698[MainThread][cafy]> ================================================================================
-Title----2025-04-20T23-08-23.701[MainThread][cafy]> Start test:  TestSections.test_debug_step2
-Info-----2025-04-20T23-08-23.705[MainThread][cafy]> Handshake for 2025_04_20_test_debug4_aHBolJWXlJNucWSYlZg796fcffb for TestSections.test_debug_step2 to registration service successful
-Info-----2025-04-20T23-08-23.706[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.706[MainThread][cafy_pytest_step]> |                   Start of step: Debugging Testcase2 Step 1                  |
-Info-----2025-04-20T23-08-23.706[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:50:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase2 Step 1                  |
-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> |                   Start of step: Debugging Testcase2 Step 2                  |
-Info-----2025-04-20T23-08-23.708[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:59:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-08-23.709[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.709[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase2 Step 2                  |
-Info-----2025-04-20T23-08-23.709[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.710[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.710[MainThread][cafy_pytest_step]> |                       Start of step: Debugging Stepss2                       |
-Info-----2025-04-20T23-08-23.710[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
Step failed here: <class 'utils.cafyexception.CafyException.CompositeError'>:Composite Error: 
    /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:69:ZeroDivisionError(division by zero)

-Info-----2025-04-20T23-08-23.712[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-20T23-08-23.712[MainThread][cafy_pytest_step]> |                       Finish of step: Debugging Stepss2                      |
-Info-----2025-04-20T23-08-23.712[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Fail-----2025-04-20T23-08-23.713[MainThread][None]> [{'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f347f9100>}, {'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f3482f040>}, {'exc_type': <class 'utils.cafyexception.CafyException.CompositeError'>, 'exc_value': CompositeError([ZeroDivisionError('division by zero')]), 'exc_tb': <traceback object at 0x7f6f3482cb80>}]
-Info-----2025-04-20T23-08-23.715[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/startdebug/v1/) to start collecting
-Info-----2025-04-20T23-08-55.389[MainThread][cafy]> Test: Debug Collector logs: {"collector_status":true}

F-Error----2025-04-20T23-08-55.393[MainThread][cafy]> stack_exception E   utils.cafyexception.CafyException.CompositeError: Composite Error: 
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:50:ZeroDivisionError(division by zero)
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:59:ZeroDivisionError(division by zero)
        /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug4.py:69:ZeroDivisionError(division by zero)
-Info-----2025-04-20T23-08-55.393[MainThread][cafy]> Teardown module for testcase TestSections.test_debug_step2
Teardown
-Info-----2025-04-20T23-08-55.419[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/end_test_case/) to check analyzer status
-Warning--2025-04-20T23-08-55.432[MainThread][cafy]> HTTP Status Code: 417
{"message": "Unexpected failure AssertionError()", "analyzer_status": false}
-Info-----2025-04-20T23-08-55.432[MainThread][cafy]> Analyzer status check failed 417
-Info-----2025-04-20T23-08-55.432[MainThread][cafy]> result of analyzer None
-Info-----2025-04-20T23-08-55.432[MainThread][cafy]> Analyzer still working, Continuing Test case
-Info-----2025-04-20T23-08-55.432[MainThread][cafy]> Analyzer Status is None
-Title----2025-04-20T23-08-55.432[MainThread][cafy]> Finish test: TestSections.test_debug_step2 (failed)
-Info-----2025-04-20T23-08-55.432[MainThread][cafy]> ======
     

**Testing :  Test log with multiple pytest.cafy.step with blocking = True** 

platform linux -- Python 3.11.4, pytest-8.3.3, pluggy-1.5.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /auto/cafy-sjc/pasverma/cafykit/test
configfile: pytest.ini
plugins: repeat-0.9.3, random-order-1.1.1, ordering-0.6, cov-6.0.0, allure-pytest-2.13.5, cafy-pytest-0.1.0
collected 2 items                                                                                                                                                                                                                                   

../cafykit/test/utils/test_debug3.py -Info-----2025-04-21T10-33-31.097[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/initiate_analyzer/) to initialize analyzer
-Warning--2025-04-21T10-33-33.216[MainThread][cafy]> HTTP Status Code: 417
{"message": "Unexpected failure AttributeError(\"'NoneType' object has no attribute 'is_alive'\",)", "analyzer_status": false}
-Warning--2025-04-21T10-33-33.216[MainThread][cafy]> Analyzer failed 417
other setup part
-Title----2025-04-21T10-33-33.218[MainThread][cafy]> Start test:  TestSections.test_debug_step
-Info-----2025-04-21T10-33-33.225[MainThread][cafy]> Handshake for 2025_04_21_test_debug3_ZGmUkpVnXmZqapCWlWg32bdc605 for TestSections.test_debug_step to registration service successful
-Info-----2025-04-21T10-33-33.226[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-33-33.226[MainThread][cafy_pytest_step]> |                  Start of step: Debugging Testcase1 Steps 1                  |
-Info-----2025-04-21T10-33-33.226[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-33-33.227[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-33-33.227[MainThread][cafy_pytest_step]> |                  Finish of step: Debugging Testcase1 Steps 1                 |
-Info-----2025-04-21T10-33-33.227[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
F-Error----2025-04-21T10-33-33.809[MainThread][cafy]> stack_exception self = <test.utils.test_debug3.TestSections object at 0x7fae12512950>

    def test_debug_step(self):
        with pytest.cafy.step('Debugging Testcase1 Steps 1', blocking=True):
            exception_list = list()
            try:
                a = 10
                b = 0
                c = a/b
            except Exception as err:
                exception_list.append(err)
>           raise CafyException.CompositeError(exception_list)
E           utils.cafyexception.CafyException.CompositeError: Composite Error: 
E               /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug3.py:19:ZeroDivisionError(division by zero)

../cafykit/test/utils/test_debug3.py:22: CompositeError
-Fail-----2025-04-21T10-33-33.817[MainThread][None]> <ExceptionInfo CompositeError([ZeroDivisionError('division by zero')]) tblen=28>
-Info-----2025-04-21T10-33-33.819[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/startdebug/v1/) to start collecting
-Info-----2025-04-21T10-34-05.504[MainThread][cafy]> Test: Debug Collector logs: {"collector_status":true}

-Info-----2025-04-21T10-34-05.507[MainThread][cafy]> Teardown module for testcase TestSections.test_debug_step
-Info-----2025-04-21T10-34-05.528[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/end_test_case/) to check analyzer status
-Info-----2025-04-21T10-34-05.544[MainThread][cafy]> result of analyzer {'status': False, 'failures': '{}'}
-Info-----2025-04-21T10-34-05.544[MainThread][cafy]> Analyzer Status is {'status': False, 'failures': '{}'}
-Title----2025-04-21T10-34-05.545[MainThread][cafy]> Finish test: TestSections.test_debug_step (failed)
-Info-----2025-04-21T10-34-05.545[MainThread][cafy]> ================================================================================
-Title----2025-04-21T10-34-05.550[MainThread][cafy]> Start test:  TestSections.test_debug_step2
-Info-----2025-04-21T10-34-05.555[MainThread][cafy]> Handshake for 2025_04_21_test_debug3_ZGmUkpVnXmZqapCWlWg32bdc605 for TestSections.test_debug_step2 to registration service successful
-Info-----2025-04-21T10-34-05.556[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-34-05.556[MainThread][cafy_pytest_step]> |                  Start of step: Debugging Testcase 2 Steps 1                 |
-Info-----2025-04-21T10-34-05.556[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-34-05.557[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
-Info-----2025-04-21T10-34-05.557[MainThread][cafy_pytest_step]> |                 Finish of step: Debugging Testcase 2 Steps 1                 |
-Info-----2025-04-21T10-34-05.557[MainThread][cafy_pytest_step]> +------------------------------------------------------------------------------+
F-Error----2025-04-21T10-34-05.561[MainThread][cafy]> stack_exception self = <test.utils.test_debug3.TestSections object at 0x7fae03346e90>

    def test_debug_step2(self):
        with pytest.cafy.step('Debugging Testcase 2 Steps 1', blocking=True):
            exception_list = list()
            try:
                a = 10
                b = 0
                c = a/b
            except Exception as err:
                exception_list.append(err)
>           raise CafyException.CompositeError(exception_list)
E           utils.cafyexception.CafyException.CompositeError: Composite Error: 
E               /auto/cafy-sjc/pasverma/cafykit/test/utils/test_debug3.py:39:ZeroDivisionError(division by zero)

../cafykit/test/utils/test_debug3.py:42: CompositeError
-Fail-----2025-04-21T10-34-05.563[MainThread][None]> <ExceptionInfo CompositeError([ZeroDivisionError('division by zero')]) tblen=28>
-Info-----2025-04-21T10-34-05.565[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/startdebug/v1/) to start collecting
-Info-----2025-04-21T10-34-37.530[MainThread][cafy]> Test: Debug Collector logs: {"collector_status":true}

-Info-----2025-04-21T10-34-37.532[MainThread][cafy]> Teardown module for testcase TestSections.test_debug_step2
Teardown
-Info-----2025-04-21T10-34-37.559[MainThread][cafy]> Calling registration service (url:http://sj6-bb28-01.cisco.com:5001/end_test_case/) to check analyzer status
-Warning--2025-04-21T10-34-37.573[MainThread][cafy]> HTTP Status Code: 417
{"message": "Unexpected failure AssertionError()", "analyzer_status": false}
-Info-----2025-04-21T10-34-37.573[MainThread][cafy]> Analyzer status check failed 417
-Info-----2025-04-21T10-34-37.573[MainThread][cafy]> result of analyzer None
-Info-----2025-04-21T10-34-37.573[MainThread][cafy]> Analyzer still working, Continuing Test case
-Info-----2025-04-21T10-34-37.573[MainThread][cafy]> Analyzer Status is None
-Title----2025-04-21T10-34-37.573[MainThread][cafy]> Finish test: TestSections.test_debug_step2 (failed)
-Info-----2025-04-21T10-34-37.574[MainThread][cafy]> ================================================================================
-Info-----2025-04-21T10-34-37.577[MainThread][cafy]> Test data generated at /auto/cafy-sjc/pasverma/cafykit/work/archive/test_debug3_20250421-103112_p1725094/testdata.json
Report successfully generated to /auto/cafy-sjc/pasverma/cafykit/work/archive/test_debug3_20250421-103112_p1725094/reports
-Info-----2025-04-21T10-34-39.886[MainThread][cafy]> Report: allure.cisco.com/auto/cafy-sjc/pasverma/cafykit/work/archive/test_debug3_20250421-103112_p1725094/reports/index.html
-Title----2025-04-21T10-34-39.886[MainThread][cafy]> End run for registration id: 2025_04_21_test_debug3_ZGmUkpVnXmZqapCWlWg32bdc605
-Info-----2025-04-21T10-35-05.005[MainThread][cafy]> 2025_04_21_test_debug3_ZGmUkpVnXmZqapCWlWg32bdc605_analyzer.log saved at /auto/cafy-sjc/pasverma/cafykit/work/archive/test_debug3_20250421-103112_p1725094
-Info-----2025-04-21T10-35-05.007[MainThread][cafy]> Calling registration upload collector logfile service (url:http://sj6-bb28-01.cisco.com:5001/uploadcollectorlogfile/)
-Info-----2025-04-21T10-35-05.015[MainThread][cafy]> Debug Collector logs: 
######################################################################################################################################################


