### PR TITLE
adding gta for exc command

### DIFF
--- a/cafy_pytest/cafy_gta.py
+++ b/cafy_pytest/cafy_gta.py
@@ -17,7 +17,8 @@ class TimeCollectorPlugin:
         self.total_sleep_time = 0
         self.total_set_command_time = 0
         self.total_get_command_time = 0
-        self.command_list = ['set_command','get_command','sleep']
+        self.total_exc_command_time = 0
+        self.command_list = ['set_command','get_command','sleep','exc_command']
 
     def update_granular_time_testcase_dict(self, current_test, event, method_name, elapsed_time, feature_type):
         """
@@ -211,6 +212,8 @@ class TimeCollectorPlugin:
                     self.total_set_command_time = self.total_set_command_time + total_sum
                 elif event == 'get_command':
                     self.total_get_command_time = self.total_get_command_time + total_sum
+                elif event == 'exc_command':
+                    self.total_exc_command_time = self.total_exc_command_time + total_sum
                 tmp_dict[command] = ["{:.2f}".format(total_sum), length, feature_type]
             else:
                 tmp_dict[command] = timings_list
@@ -236,14 +239,22 @@ class TimeCollectorPlugin:
                 time_report[test_case]['get_command'] = self.get_time_data(events["get_command"],'get_command')
             else:
                 time_report[test_case]['get_command'] = dict()
+            if 'exc_command' in events:
+                time_report[test_case]['exc_command'] = self.get_time_data(events["exc_command"],'exc_command')
+            else:
+                time_report[test_case]['exc_command'] = dict()
+
+
 
             time_report[test_case]['total_sleep_time'] = "{:.2f}".format(self.total_sleep_time)
             time_report[test_case]['total_set_command_time'] = "{:.2f}".format(self.total_set_command_time)
             time_report[test_case]['total_get_command_time'] = "{:.2f}".format(self.total_get_command_time)
-            time_report[test_case]['total_time'] = "{:.2f}".format(self.total_sleep_time+self.total_set_command_time+self.total_get_command_time)
+            time_report[test_case]['total_exc_command_time'] = "{:.2f}".format(self.total_exc_command_time)
+            time_report[test_case]['total_time'] = "{:.2f}".format(self.total_sleep_time+self.total_set_command_time+self.total_get_command_time+self.total_exc_command_time)
             self.total_sleep_time = 0
             self.total_set_command_time = 0
             self.total_get_command_time = 0
+            self.total_exc_command_time = 0
         return time_report
     
     def add_gta_data_into_db(self, time_report,aggregated_gta_data,run_id='local_run'):
@@ -300,6 +311,7 @@ class TimeCollectorPlugin:
                 'total_sleep_time': 0,
                 'total_set_command_time': 0,
                 'total_get_command_time': 0,
+                'total_exc_command_time':0,
                 'total_event_time': 0,
                 'total_run_time': run_time
                 }
@@ -307,10 +319,12 @@ class TimeCollectorPlugin:
             sleep_time = gta_data[test]['totals']['total_sleep_time']
             set_command_time = gta_data[test]['totals']['total_set_command_time']
             get_command_time = gta_data[test]['totals']['total_get_command_time']
+            exc_command_time = gta_data[test]['totals']['total_exc_command_time']
             aggregated_data['total_sleep_time'] = aggregated_data['total_sleep_time'] + sleep_time
             aggregated_data['total_set_command_time'] = aggregated_data['total_set_command_time'] + set_command_time
             aggregated_data['total_get_command_time'] = aggregated_data['total_get_command_time'] + get_command_time
-            aggregated_data['total_event_time'] = aggregated_data['total_event_time'] + sleep_time + get_command_time + set_command_time
+            aggregated_data['total_exc_command_time'] = aggregated_data['total_exc_command_time'] + exc_command_time
+            aggregated_data['total_event_time'] = aggregated_data['total_event_time'] + sleep_time + get_command_time + set_command_time + exc_command_time
         return aggregated_data
 
     def pytest_terminal_summary(self, terminalreporter):


### PR DESCRIPTION
Problem 
   Enhancement for GTA feature: Capture Time for exc command
Solution:
   Added the code logic for capturing the time for exc command
Logs:
  {"TestConnectionConsole.test_show_platform[1]": {"categories": {"sleep": [{"source": "CiscoVxrTelnet.telnet_login.time.sleep", "total_time": 5500447.27, "occurence": 5.0, "type": "infra"}, {"source": "CiscoVxrTelnet.clear_buffer.time.sleep", "total_time": 9001478.84, "occurence": 17.0, "type": "infra"}, {"source": "CiscoVxrTelnet.find_prompt_special_case.time.sleep", "total_time": 15250164.69, "occurence": 2.0, "type": "infra"}, {"source": "CiscoVxrTelnet.find_prompt.time.sleep", "total_time": 3500518.99, "occurence": 6.0, "type": "infra"}, {"source": "CiscoVxrTelnet.read_until_pattern.time.sleep", "total_time": 2964582.86, "occurence": 294.0, "type": "infra"}, {"source": "CiscoVxrTelnet.read_channel.time.sleep", "total_time": 211729.14, "occurence": 21.0, "type": "infra"}, {"source": "CiscoVxrTelnet.send_command.time.sleep", "total_time": 3487119.61, "occurence": 139.0, "type": "infra"}, {"source": "CiscoVxrSSH.read_until_pattern.time.sleep", "total_time": 1000956.61, "occurence": 10.0, "type": "infra"}, {"source": "CiscoVxrSSH.clear_buffer.time.sleep", "total_time": 2101219.04, "occurence": 13.0, "type": "infra"}, {"source": "CiscoVxrSSH.find_prompt.time.sleep", "total_time": 1000922.03, "occurence": 10.0, "type": "infra"}, {"source": "CiscoVxrSSH.send_command.time.sleep", "total_time": 900913.16, "occurence": 9.0, "type": "infra"}], "set_command": [{"source": "CafyLog.set_testcase", "total_time": 6.4, "occurence": 3.0, "type": "infra"}, {"source": "CafyLog.set_testdevice_name", "total_time": 27.44, "occurence": 10.0, "type": "infra"}, {"source": "CafyLog.set_testdevice_ip", "total_time": 28.15, "occurence": 13.0, "type": "infra"}], "get_command": [{"source": "CafyLog.get_complete_file_path", "total_time": 7867.4, "occurence": 36.0, "type": "infra"}, {"source": "Topology.get_credential", "total_time": 7.03, "occurence": 12.0, "type": "infra"}, {"source": "Topology.get_interface_type", "total_time": 26.94, "occurence": 22.0, "type": "infra"}, {"source": "CafyLog.getEffectiveLevel", "total_time": 59.86, "occurence": 36.0, "type": "infra"}, {"source": "Topology.get_device", "total_time": 6.47, "occurence": 2.0, "type": "infra"}], "exc_command": [{"source": "connection.execute.terminal_monitor_disable", "total_time": 602946.1, "occurence": 1.0, "type": "infra"}, {"source": "connection.execute.show_platform", "total_time": 5178719.03, "occurence": 4.0, "type": "infra"}]}, "totals": {"total_sleep_time": 44920052.24, "total_set_command_time": 61.99, "total_get_command_time": 7967.7, "total_exc_command_time": 5781665.13, "total_time": 50709747.06}}}